### PR TITLE
Minor fixes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ opam switch 4.04.1+fp+flambda
 ### Building the library
 
 ```
-opam install jbuilder mirage ctypes-foreign
-jbuilder external-lib-deps --missing @install runner/main.exe # Follow the opam instructions
+opam install -y jbuilder mirage ctypes-foreign
 (cd runner; mirage configure --target unix)
+jbuilder external-lib-deps --missing @install runner/main.exe cli/wodan.exe # Follow the opam instructions
 make
 ```
 


### PR DESCRIPTION
* Need to run mirage configure before jbuilder otherwise jbuilder complains
  that main.ml doesn't exist
* Add the CLI to the external-libs-deps line (otherwise base64 and csv were missing)

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>