### PR TITLE
Reformatting using ocamlformat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /wodan*.install
 .merlin
 *.img
+wodanc

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,8 @@
+break-cases=all
+break-infix=fit-or-vertical
+break-separators=after-and-docked
+field-space=loose
+margin=79
+parens-tuple=always
+sequence-style=terminator
+type-decl=sparse

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ sync:
 	git submodule update --init --recursive
 
 format:
-	# Use the master version of ocamlformat for matching results
 	git ls-files -- 'src/*.ml' 'src/*.mli' |grep -v 407 |xargs ocamlformat --inplace
 
 %.opam.locked: %.opam

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ sync:
 	git submodule sync --recursive
 	git submodule update --init --recursive
 
+format:
+	# Use the master version of ocamlformat for matching results
+	git ls-files -- 'src/*.ml' 'src/*.mli' |grep -v 407 |xargs ocamlformat --inplace
+
 %.opam.locked: %.opam
 	opam lock $^
 	# Workaround https://github.com/AltGr/opam-lock/issues/2

--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ echo performance |sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 make fuzz
 ```
 
+## Contributing
+
+The code is formatted using `ocamlformat` and complies to the options described
+in `.ocamlformat` used with the development version of `ocamlformat` (until the
+next release).
+
+Please pin the package to their git repository :
+`https://github.com/ocaml_ppx/ocamlformat`
+
+And make sure the code is well formatted before any commit by executing
+`make format`.
+
 [opam]: https://opam.ocaml.org/
 [dune]: https://github.com/ocaml/dune#installation
 [mirage]: https://mirage.io/

--- a/src/wodan-irmin/bin/wodan_git_import.ml
+++ b/src/wodan-irmin/bin/wodan_git_import.ml
@@ -1,47 +1,48 @@
-(*************************************************************************************)
-(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                          *)
-(*                                                                                   *)
-(*  Permission to use, copy, modify, and/or distribute this software for any         *)
-(*  purpose with or without fee is hereby granted, provided that the above           *)
-(*  copyright notice and this permission notice appear in all copies.                *)
-(*                                                                                   *)
-(*  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH    *)
-(*  REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND  *)
-(*  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,         *)
-(*  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM      *)
-(*  LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR    *)
-(*  OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR           *)
-(*  PERFORMANCE OF THIS SOFTWARE.                                                    *)
-(*                                                                                   *)
-(*************************************************************************************)
+(******************************************************************************)
+(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                   *)
+(*                                                                            *)
+(* Permission to use, copy, modify, and/or distribute this software for any   *)
+(* purpose with or without fee is hereby granted, provided that the above     *)
+(* copyright notice and this permission notice appear in all copies.          *)
+(*                                                                            *)
+(* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES   *)
+(* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF           *)
+(* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR    *)
+(* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES     *)
+(* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN      *)
+(* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR *)
+(* IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.                *)
+(*                                                                            *)
+(******************************************************************************)
 
-module Wodan_DB = Wodan_irmin.DB_BUILDER
-    (struct
+module Wodan_DB =
+  Wodan_irmin.DB_BUILDER (struct
       include Block
+
       let connect name = Block.connect name
     end)
     (Wodan.StandardSuperblockParams)
 
-module Wodan_nongit_S = Wodan_irmin.KV_chunked
-    (Wodan_DB)
-    (Irmin.Contents.String)
-
-module Wodan_git_S = Wodan_irmin.KV_git(Wodan_DB)
-
+module Wodan_nongit_S =
+  Wodan_irmin.KV_chunked (Wodan_DB) (Irmin.Contents.String)
+module Wodan_git_S = Wodan_irmin.KV_git (Wodan_DB)
 module Wodan_S = Wodan_git_S
 
-let wodan_config = Wodan_irmin.config
-    ~path:"git-import.img" ~create:true ()
+let wodan_config = Wodan_irmin.config ~path:"git-import.img" ~create:true ()
 
-module Git_S = Irmin_unix.Git.FS.KV(Irmin.Contents.String)
+module Git_S = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
 
 (*let git_config = Irmin_git.config @@ Sys.getcwd ()*)
 (* Use a repo that doesn't have submodules *)
 let git_config = Irmin_git.config Sys.argv.(1)
 
-module Wodan_sync = Irmin.Sync(Wodan_S)
+module Wodan_sync = Irmin.Sync (Wodan_S)
 
-module StrHash = Hashtbl.Make(struct include String let hash=Hashtbl.hash end)
+module StrHash = Hashtbl.Make (struct
+  include String
+
+  let hash = Hashtbl.hash
+end)
 
 let run () =
   let%lwt () = Nocrypto_entropy_lwt.initialize () in
@@ -56,8 +57,7 @@ let run () =
   Logs.info (fun m -> m "Loading Wodan master");
   let%lwt wodan_master = Wodan_S.master wodan_repo in
   Logs.info (fun m -> m "Fetching from Git into Wodan");
-  let%lwt head_commit =
-    Wodan_sync.fetch_exn wodan_master remote in
+  let%lwt head_commit = Wodan_sync.fetch_exn wodan_master remote in
   let%lwt () = Wodan_S.Head.set wodan_master head_commit in
   let%lwt wodan_raw = Wodan_S.DB.v wodan_config in
   let%lwt _gen = Wodan_S.DB.flush wodan_raw in
@@ -66,6 +66,7 @@ let run () =
 let () =
   Logs.set_reporter @@ Logs.format_reporter ();
   Logs.set_level @@ Some Logs.Info;
-  Logs.info @@ fun m -> m "Pwd %s" @@ Sys.getcwd ();
+  Logs.info
+  @@ fun m ->
+  m "Pwd %s" @@ Sys.getcwd ();
   Lwt_main.run @@ run ()
-

--- a/src/wodan-irmin/bin/wodan_irmin_cli.ml
+++ b/src/wodan-irmin/bin/wodan_irmin_cli.ml
@@ -1,40 +1,48 @@
-(*************************************************************************************)
-(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                          *)
-(*                                                                                   *)
-(*  Permission to use, copy, modify, and/or distribute this software for any         *)
-(*  purpose with or without fee is hereby granted, provided that the above           *)
-(*  copyright notice and this permission notice appear in all copies.                *)
-(*                                                                                   *)
-(*  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH    *)
-(*  REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND  *)
-(*  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,         *)
-(*  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM      *)
-(*  LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR    *)
-(*  OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR           *)
-(*  PERFORMANCE OF THIS SOFTWARE.                                                    *)
-(*                                                                                   *)
-(*************************************************************************************)
+(******************************************************************************)
+(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                   *)
+(*                                                                            *)
+(* Permission to use, copy, modify, and/or distribute this software for any   *)
+(* purpose with or without fee is hereby granted, provided that the above     *)
+(* copyright notice and this permission notice appear in all copies.          *)
+(*                                                                            *)
+(* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES   *)
+(* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF           *)
+(* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR    *)
+(* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES     *)
+(* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN      *)
+(* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR *)
+(* IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.                *)
+(*                                                                            *)
+(******************************************************************************)
 
 open Irmin_unix
 
 module RamBlockCon = struct
   include Ramdisk
+
   let connect name = Ramdisk.connect ~name
-  let discard _ _ _  =
-    Lwt.return @@ Ok ()
+
+  let discard _ _ _ = Lwt.return @@ Ok ()
 end
 
-module DB_ram = Wodan_irmin.DB_BUILDER(RamBlockCon)(Wodan.StandardSuperblockParams)
+module DB_ram =
+  Wodan_irmin.DB_BUILDER (RamBlockCon) (Wodan.StandardSuperblockParams)
 
 module FileBlockCon = struct
   include Block
+
   let connect name = Block.connect name
 end
 
-module DB_fs = Wodan_irmin.DB_BUILDER(FileBlockCon)(Wodan.StandardSuperblockParams)
+module DB_fs =
+  Wodan_irmin.DB_BUILDER (FileBlockCon) (Wodan.StandardSuperblockParams)
 
 let _ =
-  Resolver.Store.add "wodan-mem" (fun contents -> Resolver.Store.v ?remote:None (module Wodan_irmin.KV(DB_ram)(val contents) : Irmin.S));
-  Resolver.Store.add "wodan" ~default:true (fun contents -> Resolver.Store.v ?remote:None (module Wodan_irmin.KV(DB_fs)(val contents) : Irmin.S))
+  Resolver.Store.add "wodan-mem" (fun contents ->
+      Resolver.Store.v ?remote:None
+        (module Wodan_irmin.KV (DB_ram) ((val contents)) : Irmin.S) );
+  Resolver.Store.add "wodan" ~default:true (fun contents ->
+      Resolver.Store.v ?remote:None
+        (module Wodan_irmin.KV (DB_fs) ((val contents)) : Irmin.S) )
 
 let () = Cli.(run ~default commands)

--- a/src/wodan-irmin/wodan_irmin.ml
+++ b/src/wodan-irmin/wodan_irmin.ml
@@ -1,26 +1,28 @@
-(*************************************************************************************)
-(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                          *)
-(*                                                                                   *)
-(*  Permission to use, copy, modify, and/or distribute this software for any         *)
-(*  purpose with or without fee is hereby granted, provided that the above           *)
-(*  copyright notice and this permission notice appear in all copies.                *)
-(*                                                                                   *)
-(*  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH    *)
-(*  REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND  *)
-(*  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,         *)
-(*  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM      *)
-(*  LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR    *)
-(*  OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR           *)
-(*  PERFORMANCE OF THIS SOFTWARE.                                                    *)
-(*                                                                                   *)
-(*************************************************************************************)
+(******************************************************************************)
+(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                   *)
+(*                                                                            *)
+(* Permission to use, copy, modify, and/or distribute this software for any   *)
+(* purpose with or without fee is hereby granted, provided that the above     *)
+(* copyright notice and this permission notice appear in all copies.          *)
+(*                                                                            *)
+(* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES   *)
+(* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF           *)
+(* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR    *)
+(* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES     *)
+(* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN      *)
+(* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR *)
+(* IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.                *)
+(*                                                                            *)
+(******************************************************************************)
 
 open Lwt.Infix
 
 let src = Logs.Src.create "irmin.wodan"
+
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let standard_mount_options = {Wodan.standard_mount_options with has_tombstone = true}
+let standard_mount_options =
+  {Wodan.standard_mount_options with has_tombstone = true}
 
 module Conf = struct
   let path =
@@ -28,59 +30,76 @@ module Conf = struct
       Irmin.Private.Conf.string "wodan.img"
 
   let create =
-    Irmin.Private.Conf.key ~doc:"Whether to create a fresh filesystem" "create"
-      Irmin.Private.Conf.bool false
+    Irmin.Private.Conf.key ~doc:"Whether to create a fresh filesystem"
+      "create" Irmin.Private.Conf.bool false
 
   let cache_size =
     Irmin.Private.Conf.key ~doc:"How many cache items to keep in the LRU"
-      "cache_size"
-      Irmin.Private.Conf.int 1024
+      "cache_size" Irmin.Private.Conf.int 1024
 
   let fast_scan =
     Irmin.Private.Conf.key ~doc:"Whether to mount without scanning the leaves"
-      "fast_scan"
-      Irmin.Private.Conf.bool true
+      "fast_scan" Irmin.Private.Conf.bool true
 
   let list_key =
     Irmin.Private.Conf.key
       ~doc:"A special key used to store metadata for listing other keys"
-      "list_key"
-      Irmin.Private.Conf.string "meta:keys-list:00000"
+      "list_key" Irmin.Private.Conf.string "meta:keys-list:00000"
 
-  let autoflush = Irmin.Private.Conf.key
-      ~doc:"Whether to flush automatically when necessary for writes to go through"
-      "autoflush"
-      Irmin.Private.Conf.bool false
+  let autoflush =
+    Irmin.Private.Conf.key
+      ~doc:
+        "Whether to flush automatically when necessary for writes to go \
+         through"
+      "autoflush" Irmin.Private.Conf.bool false
 end
 
-let config ?(config=Irmin.Private.Conf.empty) ~path ~create ?cache_size ?fast_scan ?list_key ?autoflush () =
+let config ?(config = Irmin.Private.Conf.empty) ~path ~create ?cache_size
+    ?fast_scan ?list_key ?autoflush () =
   let module C = Irmin.Private.Conf in
-  let cache_size = match cache_size with
-  |None -> C.default Conf.cache_size
-  |Some cache_size -> cache_size
+  let cache_size =
+    match cache_size with
+    | None ->
+        C.default Conf.cache_size
+    | Some cache_size ->
+        cache_size
   in
-  let fast_scan = match fast_scan with
-  |None -> C.default Conf.fast_scan
-  |Some fast_scan -> fast_scan
+  let fast_scan =
+    match fast_scan with
+    | None ->
+        C.default Conf.fast_scan
+    | Some fast_scan ->
+        fast_scan
   in
-  let list_key = match list_key with
-  |None -> C.default Conf.list_key
-  |Some list_key -> list_key
+  let list_key =
+    match list_key with
+    | None ->
+        C.default Conf.list_key
+    | Some list_key ->
+        list_key
   in
-  let autoflush = match autoflush with
-  |None -> C.default Conf.autoflush
-  |Some autoflush -> autoflush
+  let autoflush =
+    match autoflush with
+    | None ->
+        C.default Conf.autoflush
+    | Some autoflush ->
+        autoflush
   in
-  (C.add (C.add (C.add (C.add (C.add (C.add config
-    Conf.autoflush autoflush)
-    Conf.list_key list_key)
-    Conf.fast_scan fast_scan)
-    Conf.cache_size cache_size)
-    Conf.path path)
-    Conf.create create)
+  C.add
+    (C.add
+       (C.add
+          (C.add
+             (C.add
+                (C.add config Conf.autoflush autoflush)
+                Conf.list_key list_key)
+             Conf.fast_scan fast_scan)
+          Conf.cache_size cache_size)
+       Conf.path path)
+    Conf.create create
 
 module type BLOCK_CON = sig
   include Wodan.EXTBLOCK
+
   (* XXX mirage-block-unix and mirage-block-ramdisk don't have the
    * exact same signature *)
   (*val connect : name:string -> t io*)
@@ -89,43 +108,57 @@ end
 
 module type DB = sig
   module Stor : Wodan.S
+
   type t
+
   val db_root : t -> Stor.root
+
   val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
   val v : Irmin.config -> t Lwt.t
+
   val flush : t -> int64 Lwt.t
 end
 
-module Cache (X: sig
-    type config
-    type t
-    type key
-    val v: config -> t Lwt.t
-    val key: config -> key
-  end): sig
+module Cache (X : sig
+  type config
+
+  type t
+
+  type key
+
+  val v : config -> t Lwt.t
+
+  val key : config -> key
+end) : sig
   val read : X.config -> (X.config * X.t) Lwt.t
 end = struct
   type key = X.key
 
   module Key = struct
     type t = key
+
     let hash = Hashtbl.hash
-    let equal = (=)
+
+    let equal = ( = )
   end
 
   (* Weak in the values *)
-  module ValueTab = Hashtbl.Make(Key)
+  module ValueTab = Hashtbl.Make (Key)
 
   module Value = struct
     type t = X.t
+
     let hash = Hashtbl.hash
-    let equal = (==)
+
+    let equal = ( == )
   end
 
   (* Weak in the keys *)
-  module ConfigTab = Ephemeron.K1.Make(Value)
+  module ConfigTab = Ephemeron.K1.Make (Value)
 
   let value_cache = ValueTab.create 10
+
   let config_cache = ConfigTab.create 10
 
   let find config =
@@ -135,12 +168,12 @@ end = struct
       let weak_t = ValueTab.find value_cache key in
       let opt_t = Weak.get weak_t 0 in
       match opt_t with
-        None -> None
-      |Some t ->
-        let config' = ConfigTab.find config_cache t in
-        Some (config', t)
-    with Not_found ->
-      None
+      | None ->
+          None
+      | Some t ->
+          let config' = ConfigTab.find config_cache t in
+          Some (config', t)
+    with Not_found -> None
 
   let add config t =
     let weak_t = Weak.create 1 in
@@ -153,359 +186,442 @@ end = struct
   let read config =
     match find config with
     | Some v ->
-      Lwt.return v
-    | None   ->
-      X.v config >|= fun t -> add config t; config, t
+        Lwt.return v
+    | None ->
+        X.v config >|= fun t -> add config t; (config, t)
 end
 
-module DB_BUILDER
-: BLOCK_CON -> Wodan.SUPERBLOCK_PARAMS -> DB
-= functor (B: BLOCK_CON) (P: Wodan.SUPERBLOCK_PARAMS) ->
-struct
-  module Stor = Wodan.Make(B)(P)
+module DB_BUILDER : functor (_ : BLOCK_CON) (_ : Wodan.SUPERBLOCK_PARAMS) -> DB =
+functor
+  (B : BLOCK_CON)
+  (P : Wodan.SUPERBLOCK_PARAMS)
+  ->
+  struct
+    module Stor = Wodan.Make (B) (P)
 
-  type t = {
-    root: Stor.root;
-    autoflush: bool;
-  }
+    type t = {
+      root : Stor.root;
+      autoflush : bool
+    }
 
-  let db_root db = db.root
+    let db_root db = db.root
 
-  let do_autoflush root op =
-    try%lwt
-      op ()
-    with Wodan.NeedsFlush ->
-      Stor.flush root >>= function _gen ->
-      op ()
+    let do_autoflush root op =
+      try%lwt op ()
+      with Wodan.NeedsFlush -> (
+        Stor.flush root
+        >>= function
+        | _gen ->
+            op () )
 
-  let may_autoflush db op =
-    if db.autoflush then do_autoflush db.root op else op ()
+    let may_autoflush db op =
+      if db.autoflush then do_autoflush db.root op else op ()
 
-  let make ~path ~create ~mount_options ~autoflush =
-    B.connect path >>= function disk ->
-    B.get_info disk >>= function info ->
-    let open_arg = if create then
-      Wodan.FormatEmptyDevice Int64.(div (mul info.size_sectors @@ of_int info.sector_size) @@ of_int Wodan.StandardSuperblockParams.block_size)
-    else Wodan.OpenExistingDevice in
-    Stor.prepare_io open_arg disk mount_options >>= fun (root, _gen) ->
-    Lwt.return { root; autoflush }
+    let make ~path ~create ~mount_options ~autoflush =
+      B.connect path
+      >>= function
+      | disk -> (
+          B.get_info disk
+          >>= function
+          | info ->
+              let open_arg =
+                if create then
+                  Wodan.FormatEmptyDevice
+                    Int64.(
+                      div (mul info.size_sectors @@ of_int info.sector_size)
+                      @@ of_int Wodan.StandardSuperblockParams.block_size)
+                else Wodan.OpenExistingDevice
+              in
+              Stor.prepare_io open_arg disk mount_options
+              >>= fun (root, _gen) -> Lwt.return {root; autoflush} )
 
-  module Cache = Cache(struct
+    module Cache = Cache (struct
       type nonrec t = t
+
       type config = string * bool * Wodan.mount_options * bool
+
       type key = string
+
       let key (path, _, _, _) = path
-      let v (path, create, mount_options, autoflush) = make ~path ~create ~mount_options ~autoflush
+
+      let v (path, create, mount_options, autoflush) =
+        make ~path ~create ~mount_options ~autoflush
     end)
 
-  let v config =
-    let module C = Irmin.Private.Conf in
-    let path = C.get config Conf.path in
-    let create = C.get config Conf.create in
-    let cache_size = C.get config Conf.cache_size in
-    let fast_scan = C.get config Conf.fast_scan in
-    let autoflush = C.get config Conf.autoflush in
-    let mount_options = {standard_mount_options with fast_scan = fast_scan; cache_size = cache_size} in
-    Cache.read (path, create, mount_options, autoflush) >|= fun ((_, create', mount_options', autoflush'), t) ->
-    assert (create=create');
-    assert (mount_options=mount_options');
-    assert (autoflush=autoflush');
-    t
+    let v config =
+      let module C = Irmin.Private.Conf in
+      let path = C.get config Conf.path in
+      let create = C.get config Conf.create in
+      let cache_size = C.get config Conf.cache_size in
+      let fast_scan = C.get config Conf.fast_scan in
+      let autoflush = C.get config Conf.autoflush in
+      let mount_options =
+        {standard_mount_options with fast_scan; cache_size}
+      in
+      Cache.read (path, create, mount_options, autoflush)
+      >|= fun ((_, create', mount_options', autoflush'), t) ->
+      assert (create = create');
+      assert (mount_options = mount_options');
+      assert (autoflush = autoflush');
+      t
 
-  let flush db =
-    Stor.flush @@ db_root db
-end
+    let flush db = Stor.flush @@ db_root db
+  end
 
-module RO_BUILDER
-: functor (DB: DB) -> functor (K: Irmin.Hash.S) -> functor (V: Irmin.Type.S) -> sig
-  include Irmin.RO
-  include DB with type t := t
-end with type key = K.t and type value = V.t
-= functor (DB: DB) (K: Irmin.Hash.S) (V: Irmin.Type.S) ->
-struct
-  include DB
-  type key = K.t
-  type value = V.t
+module RO_BUILDER : functor
+  (DB : DB)
+  (K : Irmin.Hash.S)
+  (V : Irmin.Type.S)
+  -> sig
+       include Irmin.RO
 
-  let () = assert (K.digest_size = DB.Stor.P.key_size)
+       include DB with type t := t
+     end
+     with type key = K.t
+      and type value = V.t =
+functor
+  (DB : DB)
+  (K : Irmin.Hash.S)
+  (V : Irmin.Type.S)
+  ->
+  struct
+    include DB
 
-  let find db k =
-    Log.debug (fun l -> l "find %a" (Irmin.Type.pp K.t) k);
-    Stor.lookup (db_root db) @@ Stor.key_of_string @@ Irmin.Type.encode_bin K.t k >>= function
-    |None -> Lwt.return_none
-    |Some v -> Lwt.return_some
-      @@ Rresult.R.get_ok @@ Irmin.Type.decode_bin V.t @@ Stor.string_of_value v
+    type key = K.t
 
-  let mem db k =
-    Log.debug (fun l -> l "mem %a" (Irmin.Type.pp K.t) k);
-    Stor.mem (db_root db) @@ Stor.key_of_string @@ Irmin.Type.encode_bin K.t k
-end
+    type value = V.t
 
-module AO_BUILDER
-: DB -> Irmin.AO_MAKER
-= functor (DB: DB) (K: Irmin.Hash.S) (V: Irmin.Type.S) ->
-struct
-  include RO_BUILDER(DB)(K)(V)
+    let () = assert (K.digest_size = DB.Stor.P.key_size)
 
-  let add db va =
-    let raw_v = Irmin.Type.encode_bin V.t va in
-    let k = K.digest raw_v in
-    Log.debug (fun m -> m "AO.add -> %a (%d)" (Irmin.Type.pp K.t) k K.digest_size);
-    (*Log.debug (fun m -> m "AO.add -> %a (%d) -> %a" (Irmin.Type.pp K.t) k K.digest_size (Irmin.Type.pp V.t) va);*)
-    (*Log.debug (fun m -> m "AO.add -> %a (%d) -> %s" (Irmin.Type.pp K.t) k K.digest_size raw_v);*)
-    let raw_k = Irmin.Type.encode_bin K.t k in
-    let root = db_root db in
-    may_autoflush db (fun () ->
-        Stor.insert root (Stor.key_of_string raw_k)
-        @@ Stor.value_of_string raw_v) >>=
-      function () -> Lwt.return k
-end
+    let find db k =
+      Log.debug (fun l -> l "find %a" (Irmin.Type.pp K.t) k);
+      Stor.lookup (db_root db)
+      @@ Stor.key_of_string
+      @@ Irmin.Type.encode_bin K.t k
+      >>= function
+      | None ->
+          Lwt.return_none
+      | Some v ->
+          Lwt.return_some
+          @@ Rresult.R.get_ok
+          @@ Irmin.Type.decode_bin V.t
+          @@ Stor.string_of_value v
 
-module LINK_BUILDER
-: DB -> Irmin.LINK_MAKER
-= functor (DB: DB) (K: Irmin.Hash.S) ->
-struct
-  include RO_BUILDER(DB)(K)(K)
+    let mem db k =
+      Log.debug (fun l -> l "mem %a" (Irmin.Type.pp K.t) k);
+      Stor.mem (db_root db)
+      @@ Stor.key_of_string
+      @@ Irmin.Type.encode_bin K.t k
+  end
 
-  let add db k va =
-    let raw_v = Irmin.Type.encode_bin K.t va in
-    let raw_k = Irmin.Type.encode_bin K.t k in
-    let root = db_root db in
-    Log.debug (fun m -> m "LINK.add -> %a" (Irmin.Type.pp K.t) k);
-    may_autoflush db (fun () ->
-        Stor.insert root (Stor.key_of_string raw_k)
-        @@ Stor.value_of_string raw_v)
-end
+module AO_BUILDER : functor (_ : DB) -> Irmin.AO_MAKER =
+functor
+  (DB : DB)
+  (K : Irmin.Hash.S)
+  (V : Irmin.Type.S)
+  ->
+  struct
+    include RO_BUILDER (DB) (K) (V)
 
-module RW_BUILDER
-: DB -> Irmin.Hash.S -> Irmin.RW_MAKER
-= functor (DB: DB) (H: Irmin.Hash.S)
-(K: Irmin.Type.S) (V: Irmin.Type.S) ->
-struct
-  module BUILDER = DB
-  module Stor = BUILDER.Stor
+    let add db va =
+      let raw_v = Irmin.Type.encode_bin V.t va in
+      let k = K.digest raw_v in
+      Log.debug (fun m ->
+          m "AO.add -> %a (%d)" (Irmin.Type.pp K.t) k K.digest_size );
+      (*Log.debug (fun m -> m "AO.add -> %a (%d) -> %a" (Irmin.Type.pp K.t) k K.digest_size (Irmin.Type.pp V.t) va);*)
+      (*Log.debug (fun m -> m "AO.add -> %a (%d) -> %s" (Irmin.Type.pp K.t) k K.digest_size raw_v);*)
+      let raw_k = Irmin.Type.encode_bin K.t k in
+      let root = db_root db in
+      may_autoflush db (fun () ->
+          Stor.insert root (Stor.key_of_string raw_k)
+          @@ Stor.value_of_string raw_v )
+      >>= function
+      | () ->
+          Lwt.return k
+  end
 
-  module KeyHashtbl = Hashtbl.Make(Stor.Key)
-  module W = Irmin.Private.Watch.Make(K)(V)
-  module L = Irmin.Private.Lock.Make(K)
+module LINK_BUILDER : functor (_ : DB) -> Irmin.LINK_MAKER =
+functor
+  (DB : DB)
+  (K : Irmin.Hash.S)
+  ->
+  struct
+    include RO_BUILDER (DB) (K) (K)
 
-  type t = {
-    nested: BUILDER.t;
-    keydata: Stor.key KeyHashtbl.t;
-    mutable magic_key: Stor.key;
-    watches: W.t;
-    lock: L.t;
-  }
+    let add db k va =
+      let raw_v = Irmin.Type.encode_bin K.t va in
+      let raw_k = Irmin.Type.encode_bin K.t k in
+      let root = db_root db in
+      Log.debug (fun m -> m "LINK.add -> %a" (Irmin.Type.pp K.t) k);
+      may_autoflush db (fun () ->
+          Stor.insert root (Stor.key_of_string raw_k)
+          @@ Stor.value_of_string raw_v )
+  end
 
-  let db_root db = BUILDER.db_root db.nested
-  let may_autoflush db = BUILDER.may_autoflush db.nested
+module RW_BUILDER : functor (_ : DB) (_ : Irmin.Hash.S) -> Irmin.RW_MAKER =
+functor
+  (DB : DB)
+  (H : Irmin.Hash.S)
+  (K : Irmin.Type.S)
+  (V : Irmin.Type.S)
+  ->
+  struct
+    module BUILDER = DB
+    module Stor = BUILDER.Stor
+    module KeyHashtbl = Hashtbl.Make (Stor.Key)
+    module W = Irmin.Private.Watch.Make (K) (V)
+    module L = Irmin.Private.Lock.Make (K)
 
-  let () = assert (H.digest_size = Stor.P.key_size)
+    type t = {
+      nested : BUILDER.t;
+      keydata : Stor.key KeyHashtbl.t;
+      mutable magic_key : Stor.key;
+      watches : W.t;
+      lock : L.t
+    }
 
-  type key = K.t
-  type value = V.t
+    let db_root db = BUILDER.db_root db.nested
 
-  let key_to_inner_key k = Stor.key_of_string @@ Irmin.Type.encode_bin H.t @@ H.digest @@ Irmin.Type.encode_bin K.t k
-  let val_to_inner_val va = Stor.value_of_string @@ Irmin.Type.encode_bin V.t va
-  let key_to_inner_val k = Stor.value_of_string @@ Irmin.Type.encode_bin K.t k
-  let key_of_inner_val va =
-    Rresult.R.get_ok @@ Irmin.Type.decode_bin K.t @@ Stor.string_of_value va
-  let val_of_inner_val va =
-    Rresult.R.get_ok @@ Irmin.Type.decode_bin V.t
-    @@ Stor.string_of_value va
-  let inner_val_to_inner_key va =
-    Stor.key_of_string @@ (Irmin.Type.encode_bin H.t) @@ H.digest
-    @@ Stor.string_of_value va
+    let may_autoflush db = BUILDER.may_autoflush db.nested
 
-  let make ~list_key ~config =
-    let%lwt db = BUILDER.v config in
-    let root = BUILDER.db_root db in
-    let magic_key = Bytes.make H.digest_size '\000' in
-    Bytes.blit_string list_key 0 magic_key 0 (String.length list_key);
-    let db = {
-      nested = db;
-      keydata = KeyHashtbl.create 10;
-      magic_key = Stor.key_of_string (Bytes.unsafe_to_string magic_key) ;
-      watches = W.v ();
-      lock = L.v ();
-    } in
-    begin try%lwt
-        while%lwt true do
-          Stor.lookup root db.magic_key >>= function
-          |None -> Lwt.fail Exit
-          |Some va -> begin
-              let ik = inner_val_to_inner_key va in
-              KeyHashtbl.add db.keydata ik db.magic_key;
-              db.magic_key <- Stor.next_key db.magic_key;
-              Lwt.return_unit
-            end
-        done
-      with Exit -> Lwt.return_unit
-    end >|= fun () -> db
+    let () = assert (H.digest_size = Stor.P.key_size)
 
-  module Cache = Cache(struct
+    type key = K.t
+
+    type value = V.t
+
+    let key_to_inner_key k =
+      Stor.key_of_string
+      @@ Irmin.Type.encode_bin H.t
+      @@ H.digest
+      @@ Irmin.Type.encode_bin K.t k
+
+    let val_to_inner_val va =
+      Stor.value_of_string @@ Irmin.Type.encode_bin V.t va
+
+    let key_to_inner_val k =
+      Stor.value_of_string @@ Irmin.Type.encode_bin K.t k
+
+    let key_of_inner_val va =
+      Rresult.R.get_ok @@ Irmin.Type.decode_bin K.t @@ Stor.string_of_value va
+
+    let val_of_inner_val va =
+      Rresult.R.get_ok @@ Irmin.Type.decode_bin V.t @@ Stor.string_of_value va
+
+    let inner_val_to_inner_key va =
+      Stor.key_of_string
+      @@ Irmin.Type.encode_bin H.t
+      @@ H.digest
+      @@ Stor.string_of_value va
+
+    let make ~list_key ~config =
+      let%lwt db = BUILDER.v config in
+      let root = BUILDER.db_root db in
+      let magic_key = Bytes.make H.digest_size '\000' in
+      Bytes.blit_string list_key 0 magic_key 0 (String.length list_key);
+      let db =
+        { nested = db;
+          keydata = KeyHashtbl.create 10;
+          magic_key = Stor.key_of_string (Bytes.unsafe_to_string magic_key);
+          watches = W.v ();
+          lock = L.v () }
+      in
+      ( try%lwt
+              while%lwt true do
+                Stor.lookup root db.magic_key
+                >>= function
+                | None ->
+                    Lwt.fail Exit
+                | Some va ->
+                    let ik = inner_val_to_inner_key va in
+                    KeyHashtbl.add db.keydata ik db.magic_key;
+                    db.magic_key <- Stor.next_key db.magic_key;
+                    Lwt.return_unit
+              done
+        with Exit -> Lwt.return_unit )
+      >|= fun () -> db
+
+    module Cache = Cache (struct
       type nonrec t = t
+
       type config = string * string * Irmin.Private.Conf.t
+
       type key = string
+
       let key (path, _, _) = path
-      let v (_, list_key, config) =
-        make ~list_key ~config
+
+      let v (_, list_key, config) = make ~list_key ~config
     end)
 
-  let v config =
-    let module C = Irmin.Private.Conf in
-    let list_key = C.get config Conf.list_key in
-    let path = C.get config Conf.path in
-    Cache.read (path, list_key, config) >|=
-    fun ((_, list_key', _), t) ->
-    assert (list_key=list_key');
-    t
+    let v config =
+      let module C = Irmin.Private.Conf in
+      let list_key = C.get config Conf.list_key in
+      let path = C.get config Conf.path in
+      Cache.read (path, list_key, config)
+      >|= fun ((_, list_key', _), t) ->
+      assert (list_key = list_key');
+      t
 
-  let set_and_list db ik iv ikv =
-    assert (not @@ Stor.is_tombstone (db_root db) iv);
-    begin if not @@ KeyHashtbl.mem db.keydata ik then begin
-      KeyHashtbl.add db.keydata ik db.magic_key;
-      may_autoflush db
-      (fun () -> Stor.insert (db_root db) db.magic_key ikv)
-      >>= fun () -> begin
+    let set_and_list db ik iv ikv =
+      assert (not @@ Stor.is_tombstone (db_root db) iv);
+      ( if not @@ KeyHashtbl.mem db.keydata ik then (
+        KeyHashtbl.add db.keydata ik db.magic_key;
+        may_autoflush db (fun () -> Stor.insert (db_root db) db.magic_key ikv)
+        >>= fun () ->
         db.magic_key <- Stor.next_key db.magic_key;
-        Lwt.return_unit
-      end
-    end
-    else Lwt.return_unit end
-    >>= fun () ->
-    may_autoflush db
-      (fun () -> Stor.insert (db_root db) ik iv)
+        Lwt.return_unit )
+      else Lwt.return_unit )
+      >>= fun () -> may_autoflush db (fun () -> Stor.insert (db_root db) ik iv)
 
-  let set db k va =
-    Log.debug (fun m -> m "RW.set -> %a" (Irmin.Type.pp K.t) k);
-    let ik = key_to_inner_key k in
-    let iv = val_to_inner_val va in
-    L.with_lock db.lock k (fun () ->
-    set_and_list db ik iv @@ key_to_inner_val k)
-    >>= fun () -> W.notify db.watches k (Some va)
+    let set db k va =
+      Log.debug (fun m -> m "RW.set -> %a" (Irmin.Type.pp K.t) k);
+      let ik = key_to_inner_key k in
+      let iv = val_to_inner_val va in
+      L.with_lock db.lock k (fun () ->
+          set_and_list db ik iv @@ key_to_inner_val k )
+      >>= fun () -> W.notify db.watches k (Some va)
 
-  type watch = W.watch
+    type watch = W.watch
 
-  let watch db = W.watch db.watches
-  let watch_key db = W.watch_key db.watches
-  let unwatch db = W.unwatch db.watches
+    let watch db = W.watch db.watches
 
-  let opt_equal f x y = match x, y with
-    | None  ,  None  -> true
-    | Some x, Some y -> f x y
-    | _ -> false
+    let watch_key db = W.watch_key db.watches
 
-  (* XXX With autoflush, this might flush some data without finishing the insert *)
-  let test_and_set db k ~test ~set =
-    Log.debug (fun m -> m "RW.test_and_set -> %a" (Irmin.Type.pp K.t) k);
-    let ik = key_to_inner_key k in
-    let root = db_root db in
-    let test = match test with
-    |Some va -> Some (val_to_inner_val va)
-    |None -> None in
-    L.with_lock db.lock k (fun () ->
-      Stor.lookup root @@ ik >>= function v0 ->
-      if opt_equal Stor.value_equal v0 test then begin
-        match set with
-        |Some va ->
-            set_and_list db ik (val_to_inner_val va) @@ key_to_inner_val k
-        |None ->
-            may_autoflush db (fun () ->
-              Stor.insert root ik @@ Stor.value_of_string "")
-      end >>= fun () -> Lwt.return_true
-      else Lwt.return_false
-    ) >>= fun updated -> begin
-      if updated then W.notify db.watches k set else Lwt.return_unit
-    end >>= fun () -> Lwt.return updated
+    let unwatch db = W.unwatch db.watches
 
-  let remove db k =
-    Log.debug (fun l -> l "RW.remove %a" (Irmin.Type.pp K.t) k);
-    let ik = key_to_inner_key k in
-    let va = Stor.value_of_string "" in
-    let root = db_root db in
-    L.with_lock db.lock k (fun () ->
-        may_autoflush db (fun () ->
-            Stor.insert root ik va)) >>= fun () ->
-    W.notify db.watches k None
+    let opt_equal f x y =
+      match (x, y) with
+      | None, None ->
+          true
+      | Some x, Some y ->
+          f x y
+      | _ ->
+          false
 
-  let list db =
-    Log.debug (fun l -> l "RW.list");
-    let root = db_root db in
-    KeyHashtbl.fold (fun ik mk io ->
-      io >>= function l ->
-        Stor.mem root ik >>= function
-          |true -> begin
-            Stor.lookup root mk >>= function
-              |None -> Lwt.fail @@ Failure "Missing metadata key"
-              |Some iv -> Lwt.return @@ (key_of_inner_val iv) :: l
-          end
-          |false -> Lwt.return l
-    ) db.keydata @@ Lwt.return []
+    (* XXX With autoflush, this might flush some data without finishing the insert *)
+    let test_and_set db k ~test ~set =
+      Log.debug (fun m -> m "RW.test_and_set -> %a" (Irmin.Type.pp K.t) k);
+      let ik = key_to_inner_key k in
+      let root = db_root db in
+      let test =
+        match test with
+        | Some va ->
+            Some (val_to_inner_val va)
+        | None ->
+            None
+      in
+      L.with_lock db.lock k (fun () ->
+          Stor.lookup root @@ ik
+          >>= function
+          | v0 ->
+              if opt_equal Stor.value_equal v0 test then
+                ( match set with
+                | Some va ->
+                    set_and_list db ik (val_to_inner_val va)
+                    @@ key_to_inner_val k
+                | None ->
+                    may_autoflush db (fun () ->
+                        Stor.insert root ik @@ Stor.value_of_string "" ) )
+                >>= fun () -> Lwt.return_true
+              else Lwt.return_false )
+      >>= fun updated ->
+      (if updated then W.notify db.watches k set else Lwt.return_unit)
+      >>= fun () -> Lwt.return updated
 
-  let find db k =
-    Log.debug (fun l -> l "RW.find %a" (Irmin.Type.pp K.t) k);
-    Stor.lookup (db_root db) @@ key_to_inner_key k >>= function
-    |None -> Lwt.return_none
-    |Some va -> Lwt.return_some @@ val_of_inner_val va
+    let remove db k =
+      Log.debug (fun l -> l "RW.remove %a" (Irmin.Type.pp K.t) k);
+      let ik = key_to_inner_key k in
+      let va = Stor.value_of_string "" in
+      let root = db_root db in
+      L.with_lock db.lock k (fun () ->
+          may_autoflush db (fun () -> Stor.insert root ik va) )
+      >>= fun () -> W.notify db.watches k None
 
-  let mem db k =
-    Stor.mem (db_root db) @@ key_to_inner_key k
-end
+    let list db =
+      Log.debug (fun l -> l "RW.list");
+      let root = db_root db in
+      KeyHashtbl.fold
+        (fun ik mk io ->
+          io
+          >>= function
+          | l -> (
+              Stor.mem root ik
+              >>= function
+              | true -> (
+                  Stor.lookup root mk
+                  >>= function
+                  | None ->
+                      Lwt.fail @@ Failure "Missing metadata key"
+                  | Some iv ->
+                      Lwt.return @@ (key_of_inner_val iv :: l) )
+              | false ->
+                  Lwt.return l ) )
+        db.keydata
+      @@ Lwt.return []
 
-module Make (DB: DB)
-(M: Irmin.Metadata.S)
-(C: Irmin.Contents.S)
-(P: Irmin.Path.S)
-(B: Irmin.Branch.S)
-(H: Irmin.Hash.S)
-= struct
+    let find db k =
+      Log.debug (fun l -> l "RW.find %a" (Irmin.Type.pp K.t) k);
+      Stor.lookup (db_root db) @@ key_to_inner_key k
+      >>= function
+      | None ->
+          Lwt.return_none
+      | Some va ->
+          Lwt.return_some @@ val_of_inner_val va
+
+    let mem db k = Stor.mem (db_root db) @@ key_to_inner_key k
+  end
+
+module Make
+    (DB : DB)
+    (M : Irmin.Metadata.S)
+    (C : Irmin.Contents.S)
+    (P : Irmin.Path.S)
+    (B : Irmin.Branch.S)
+    (H : Irmin.Hash.S) =
+struct
   module DB = DB
-  module AO = AO_BUILDER(DB)
-  module RW = RW_BUILDER(DB)(H)
-  include Irmin.Make(AO)(RW)(M)(C)(P)(B)(H)
+  module AO = AO_BUILDER (DB)
+  module RW = RW_BUILDER (DB) (H)
+  include Irmin.Make (AO) (RW) (M) (C) (P) (B) (H)
+
   let flush = DB.flush
 end
 
 (* XXX Stable chunking or not? *)
-module Make_chunked (DB: DB)
-(M: Irmin.Metadata.S)
-(C: Irmin.Contents.S)
-(P: Irmin.Path.S)
-(B: Irmin.Branch.S)
-(H: Irmin.Hash.S)
-= struct
-  module AO = Irmin_chunk.AO(AO_BUILDER(DB))
+module Make_chunked
+    (DB : DB)
+    (M : Irmin.Metadata.S)
+    (C : Irmin.Contents.S)
+    (P : Irmin.Path.S)
+    (B : Irmin.Branch.S)
+    (H : Irmin.Hash.S) =
+struct
+  module AO = Irmin_chunk.AO (AO_BUILDER (DB))
   module DB = DB
-  module RW = RW_BUILDER(DB)(H)
-  include Irmin.Make(AO)(RW)(M)(C)(P)(B)(H)
+  module RW = RW_BUILDER (DB) (H)
+  include Irmin.Make (AO) (RW) (M) (C) (P) (B) (H)
+
   let flush = DB.flush
 end
 
-module KV (DB: DB) (C: Irmin.Contents.S)
-= Make(DB)
-  (Irmin.Metadata.None)
-  (C)
-  (Irmin.Path.String_list)
-  (Irmin.Branch.String)
-  (Irmin.Hash.SHA1)
+module KV (DB : DB) (C : Irmin.Contents.S) =
+  Make (DB) (Irmin.Metadata.None) (C) (Irmin.Path.String_list)
+    (Irmin.Branch.String)
+    (Irmin.Hash.SHA1)
 
-module KV_git (DB: DB)
-= struct
+module KV_git (DB : DB) = struct
   module DB = DB
+
   (*module AO = AO_BUILDER(DB)*)
   (*module AO = Irmin_chunk.AO(AO_BUILDER(DB))*)
-  module AO = Irmin_chunk.AO_stable(LINK_BUILDER(DB))(AO_BUILDER(DB))
-  module RW = RW_BUILDER(DB)(Irmin.Hash.SHA1)
-  include Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String)
+  module AO = Irmin_chunk.AO_stable (LINK_BUILDER (DB)) (AO_BUILDER (DB))
+  module RW = RW_BUILDER (DB) (Irmin.Hash.SHA1)
+  include Irmin_git.Generic_KV (AO) (RW) (Irmin.Contents.String)
+
   let flush = DB.flush
 end
 
-module KV_chunked (DB: DB) (C: Irmin.Contents.S)
-= Make_chunked(DB)
-  (Irmin.Metadata.None)
-  (C)
-  (Irmin.Path.String_list)
-  (Irmin.Branch.String)
-  (Irmin.Hash.SHA1)
-
+module KV_chunked (DB : DB) (C : Irmin.Contents.S) =
+  Make_chunked (DB) (Irmin.Metadata.None) (C) (Irmin.Path.String_list)
+    (Irmin.Branch.String)
+    (Irmin.Hash.SHA1)

--- a/src/wodan-irmin/wodan_irmin.mli
+++ b/src/wodan-irmin/wodan_irmin.mli
@@ -1,3725 +1,6338 @@
-
 module Log : Logs.LOG
+
 val standard_mount_options : Wodan.mount_options
-module Conf :
-  sig
-    val path : string Irmin.Private.Conf.key
-    val create : bool Irmin.Private.Conf.key
-    val cache_size : int Irmin.Private.Conf.key
-    val fast_scan : bool Irmin.Private.Conf.key
-    val list_key : string Irmin.Private.Conf.key
-    val autoflush : bool Irmin.Private.Conf.key
-  end
+
+module Conf : sig
+  val path : string Irmin.Private.Conf.key
+
+  val create : bool Irmin.Private.Conf.key
+
+  val cache_size : int Irmin.Private.Conf.key
+
+  val fast_scan : bool Irmin.Private.Conf.key
+
+  val list_key : string Irmin.Private.Conf.key
+
+  val autoflush : bool Irmin.Private.Conf.key
+end
+
 val config :
   ?config:Irmin.config ->
   path:string ->
   create:bool ->
   ?cache_size:int ->
   ?fast_scan:bool ->
-  ?list_key:string -> ?autoflush:bool -> unit -> Irmin.config
-module type BLOCK_CON =
-  sig
-    include Wodan.EXTBLOCK
-    val connect : string -> t io
-  end
-module type DB =
-  sig
+  ?list_key:string ->
+  ?autoflush:bool ->
+  unit ->
+  Irmin.config
+
+module type BLOCK_CON = sig
+  include Wodan.EXTBLOCK
+
+  val connect : string -> t io
+end
+
+module type DB = sig
+  module Stor : Wodan.S
+
+  type t
+
+  val db_root : t -> Stor.root
+
+  val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
+  val v : Irmin.config -> t Lwt.t
+
+  val flush : t -> int64 Lwt.t
+end
+
+module DB_BUILDER : functor (_ : BLOCK_CON) (_ : Wodan.SUPERBLOCK_PARAMS) -> DB
+
+module RO_BUILDER (DB : DB) (K : Irmin.Hash.S) (V : Irmin.Type.S) : sig
+  type t
+
+  type key = K.t
+
+  type value = V.t
+
+  val mem : t -> key -> bool Lwt.t
+
+  val find : t -> key -> value option Lwt.t
+
+  module Stor : Wodan.S
+
+  val db_root : t -> Stor.root
+
+  val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
+  val v : Irmin.config -> t Lwt.t
+
+  val flush : t -> int64 Lwt.t
+end
+
+module AO_BUILDER : functor (_ : DB) -> Irmin.AO_MAKER
+
+module LINK_BUILDER : functor (_ : DB) -> Irmin.LINK_MAKER
+
+module RW_BUILDER : functor (_ : DB) (_ : Irmin.Hash.S) -> Irmin.RW_MAKER
+
+module Make
+    (DB : DB)
+    (M : Irmin.Metadata.S)
+    (C : Irmin.Contents.S)
+    (P : Irmin.Path.S)
+    (B : Irmin.Branch.S)
+    (H : Irmin.Hash.S) : sig
+  module DB : sig
     module Stor : Wodan.S
-    type t
+
+    type t = DB.t
+
     val db_root : t -> Stor.root
+
     val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
     val v : Irmin.config -> t Lwt.t
+
     val flush : t -> int64 Lwt.t
   end
-module DB_BUILDER : BLOCK_CON -> Wodan.SUPERBLOCK_PARAMS -> DB
-module RO_BUILDER :
-  functor (DB : DB) (K : Irmin.Hash.S) (V : Irmin.Type.S) ->
-    sig
-      type t
-      type key = K.t
-      type value = V.t
+
+  module AO (K : Irmin.Hash.S) (V : Irmin.Type.S) : sig
+    type t = AO_BUILDER(DB)(K)(V).t
+
+    type key = K.t
+
+    type value = V.t
+
+    val mem : t -> key -> bool Lwt.t
+
+    val find : t -> key -> value option Lwt.t
+
+    val add : t -> value -> key Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+  end
+
+  module RW (K : Irmin.Type.S) (V : Irmin.Type.S) : sig
+    type t = RW_BUILDER(DB)(H)(K)(V).t
+
+    type key = K.t
+
+    type value = V.t
+
+    val mem : t -> key -> bool Lwt.t
+
+    val find : t -> key -> value option Lwt.t
+
+    val set : t -> key -> value -> unit Lwt.t
+
+    val test_and_set :
+      t -> key -> test:value option -> set:value option -> bool Lwt.t
+
+    val remove : t -> key -> unit Lwt.t
+
+    val list : t -> key list Lwt.t
+
+    type watch = RW_BUILDER(DB)(H)(K)(V).watch
+
+    val watch :
+      t ->
+      ?init:(key * value) list ->
+      (key -> value Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val watch_key :
+      t ->
+      key ->
+      ?init:value ->
+      (value Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val unwatch : t -> watch -> unit Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+  end
+
+  type repo = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).repo
+
+  type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).t
+
+  type step = P.step
+
+  type key = P.t
+
+  type metadata = M.t
+
+  type contents = C.t
+
+  type node = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).node
+
+  type tree =
+    [ `Contents of contents * metadata
+    | `Node of node ]
+
+  type commit = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).commit
+
+  type branch = B.t
+
+  type slice = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).slice
+
+  type lca_error =
+    [ `Max_depth_reached
+    | `Too_many_lcas ]
+
+  type ff_error =
+    [ `Max_depth_reached
+    | `No_change
+    | `Rejected
+    | `Too_many_lcas ]
+
+  module Repo : sig
+    type t = repo
+
+    val v : Irmin.config -> t Lwt.t
+
+    val heads : t -> commit list Lwt.t
+
+    val branches : t -> branch list Lwt.t
+
+    val export :
+      ?full:bool ->
+      ?depth:int ->
+      ?min:commit list ->
+      ?max:commit list ->
+      t ->
+      slice Lwt.t
+
+    val import : t -> slice -> (unit, [`Msg of string]) result Lwt.t
+  end
+
+  val empty : repo -> t Lwt.t
+
+  val master : repo -> t Lwt.t
+
+  val of_branch : repo -> branch -> t Lwt.t
+
+  val of_commit : commit -> t Lwt.t
+
+  val repo : t -> repo
+
+  val tree : t -> tree Lwt.t
+
+  module Status : sig
+    type t =
+      [ `Branch of branch
+      | `Commit of commit
+      | `Empty ]
+
+    val t : repo -> t Irmin.Type.ty
+
+    val pp : t Fmt.t
+  end
+
+  val status : t -> Status.t
+
+  module Head : sig
+    val list : repo -> commit list Lwt.t
+
+    val find : t -> commit option Lwt.t
+
+    val get : t -> commit Lwt.t
+
+    val set : t -> commit -> unit Lwt.t
+
+    val fast_forward :
+      t ->
+      ?max_depth:int ->
+      ?n:int ->
+      commit ->
+      ( unit,
+        [`Max_depth_reached | `No_change | `Rejected | `Too_many_lcas] )
+      result
+      Lwt.t
+
+    val test_and_set :
+      t -> test:commit option -> set:commit option -> bool Lwt.t
+
+    val merge :
+      into:t ->
+      info:Irmin.Info.f ->
+      ?max_depth:int ->
+      ?n:int ->
+      commit ->
+      (unit, Irmin.Merge.conflict) result Lwt.t
+  end
+
+  module Commit : sig
+    type t = commit
+
+    val t : repo -> t Irmin.Type.ty
+
+    val pp_hash : t Fmt.t
+
+    val v : repo -> info:Irmin.Info.t -> parents:t list -> tree -> t Lwt.t
+
+    val tree : t -> tree Lwt.t
+
+    val parents : t -> t list Lwt.t
+
+    val info : t -> Irmin.Info.t
+
+    module Hash : sig
+      type t = H.t
+
+      val digest : string -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash = Hash.t
+
+    val hash : t -> hash
+
+    val of_hash : repo -> hash -> t option Lwt.t
+  end
+
+  module Contents : sig
+    type t = contents
+
+    val t : t Irmin.Type.ty
+
+    val merge : t option Irmin.Merge.t
+
+    module Hash : sig
+      type t = Commit.hash
+
+      val digest : string -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash = Hash.t
+
+    val hash : repo -> t -> hash Lwt.t
+
+    val of_hash : repo -> hash -> t option Lwt.t
+  end
+
+  module Tree : sig
+    val empty : tree
+
+    val of_contents : ?metadata:metadata -> contents -> tree
+
+    val of_node : node -> tree
+
+    val kind : tree -> key -> [`Contents | `Node] option Lwt.t
+
+    val list : tree -> key -> (step * [`Contents | `Node]) list Lwt.t
+
+    val diff :
+      tree -> tree -> (key * (contents * metadata) Irmin.diff) list Lwt.t
+
+    val mem : tree -> key -> bool Lwt.t
+
+    val find_all : tree -> key -> (contents * metadata) option Lwt.t
+
+    val find : tree -> key -> contents option Lwt.t
+
+    val get_all : tree -> key -> (contents * metadata) Lwt.t
+
+    val get : tree -> key -> contents Lwt.t
+
+    val add : tree -> key -> ?metadata:metadata -> contents -> tree Lwt.t
+
+    val remove : tree -> key -> tree Lwt.t
+
+    val mem_tree : tree -> key -> bool Lwt.t
+
+    val find_tree : tree -> key -> tree option Lwt.t
+
+    val get_tree : tree -> key -> tree Lwt.t
+
+    val add_tree : tree -> key -> tree -> tree Lwt.t
+
+    val merge : tree Irmin.Merge.t
+
+    val clear_caches : tree -> unit
+
+    type marks = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Tree.marks
+
+    val empty_marks : unit -> marks
+
+    type 'a force =
+      [ `False of key -> 'a -> 'a Lwt.t
+      | `True ]
+
+    type uniq =
+      [ `False
+      | `Marks of marks
+      | `True ]
+
+    type 'a node_fn = key -> step list -> 'a -> 'a Lwt.t
+
+    val fold :
+      ?force:'a force ->
+      ?uniq:uniq ->
+      ?pre:'a node_fn ->
+      ?post:'a node_fn ->
+      (key -> contents -> 'a -> 'a Lwt.t) ->
+      tree ->
+      'a ->
+      'a Lwt.t
+
+    type stats = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Tree.stats = {
+      nodes : int;
+      leafs : int;
+      skips : int;
+      depth : int;
+      width : int
+    }
+
+    val pp_stats : stats Fmt.t
+
+    val stats : ?force:bool -> tree -> stats Lwt.t
+
+    type concrete =
+      [ `Contents of contents * metadata
+      | `Tree of (step * concrete) list ]
+
+    val of_concrete : concrete -> tree
+
+    val to_concrete : tree -> concrete Lwt.t
+
+    module Hash : sig
+      type t = Contents.hash
+
+      val digest : string -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash =
+      [ `Contents of Hash.t * metadata
+      | `Node of Hash.t ]
+
+    val hash_t : hash Irmin.Type.ty
+
+    val hash : repo -> tree -> hash Lwt.t
+
+    val of_hash : repo -> hash -> tree option Lwt.t
+  end
+
+  val kind : t -> key -> [`Contents | `Node] option Lwt.t
+
+  val list : t -> key -> (step * [`Contents | `Node]) list Lwt.t
+
+  val mem : t -> key -> bool Lwt.t
+
+  val mem_tree : t -> key -> bool Lwt.t
+
+  val find_all : t -> key -> (contents * metadata) option Lwt.t
+
+  val find : t -> key -> contents option Lwt.t
+
+  val get_all : t -> key -> (contents * metadata) Lwt.t
+
+  val get : t -> key -> contents Lwt.t
+
+  val find_tree : t -> key -> tree option Lwt.t
+
+  val get_tree : t -> key -> tree Lwt.t
+
+  type 'a transaction =
+    ?retries:int ->
+    ?allow_empty:bool ->
+    ?strategy:[`Merge_with_parent of commit | `Set | `Test_and_set] ->
+    info:Irmin.Info.f ->
+    'a ->
+    unit Lwt.t
+
+  val with_tree : t -> key -> (tree option -> tree option Lwt.t) transaction
+
+  val set : t -> key -> ?metadata:metadata -> contents transaction
+
+  val set_tree : t -> key -> tree transaction
+
+  val remove : t -> key transaction
+
+  val clone : src:t -> dst:branch -> t Lwt.t
+
+  type watch = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).watch
+
+  val watch :
+    t -> ?init:commit -> (commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
+
+  val watch_key :
+    t ->
+    key ->
+    ?init:commit ->
+    ((commit * tree) Irmin.diff -> unit Lwt.t) ->
+    watch Lwt.t
+
+  val unwatch : watch -> unit Lwt.t
+
+  type 'a merge =
+    info:Irmin.Info.f ->
+    ?max_depth:int ->
+    ?n:int ->
+    'a ->
+    (unit, Irmin.Merge.conflict) result Lwt.t
+
+  val merge : into:t -> t merge
+
+  val merge_with_branch : t -> branch merge
+
+  val merge_with_commit : t -> commit merge
+
+  val lcas :
+    ?max_depth:int ->
+    ?n:int ->
+    t ->
+    t ->
+    (commit list, lca_error) result Lwt.t
+
+  val lcas_with_branch :
+    t ->
+    ?max_depth:int ->
+    ?n:int ->
+    branch ->
+    (commit list, lca_error) result Lwt.t
+
+  val lcas_with_commit :
+    t ->
+    ?max_depth:int ->
+    ?n:int ->
+    commit ->
+    (commit list, lca_error) result Lwt.t
+
+  module History : sig
+    type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.t
+
+    module V : sig
+      type t = commit
+
+      val compare : t -> t -> int
+
+      val hash : t -> int
+
+      val equal : t -> t -> bool
+
+      type label = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.V.label
+
+      val create : label -> t
+
+      val label : t -> label
+    end
+
+    type vertex = commit
+
+    module E : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.E.t
+
+      val compare : t -> t -> int
+
+      type vertex = commit
+
+      val src : t -> vertex
+
+      val dst : t -> vertex
+
+      type label = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.E.label
+
+      val create : vertex -> label -> vertex -> t
+
+      val label : t -> label
+    end
+
+    type edge = E.t
+
+    val is_directed : bool
+
+    val is_empty : t -> bool
+
+    val nb_vertex : t -> int
+
+    val nb_edges : t -> int
+
+    val out_degree : t -> vertex -> int
+
+    val in_degree : t -> vertex -> int
+
+    val mem_vertex : t -> vertex -> bool
+
+    val mem_edge : t -> vertex -> vertex -> bool
+
+    val mem_edge_e : t -> edge -> bool
+
+    val find_edge : t -> vertex -> vertex -> edge
+
+    val find_all_edges : t -> vertex -> vertex -> edge list
+
+    val succ : t -> vertex -> vertex list
+
+    val pred : t -> vertex -> vertex list
+
+    val succ_e : t -> vertex -> edge list
+
+    val pred_e : t -> vertex -> edge list
+
+    val iter_vertex : (vertex -> unit) -> t -> unit
+
+    val fold_vertex : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val iter_edges : (vertex -> vertex -> unit) -> t -> unit
+
+    val fold_edges : (vertex -> vertex -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val iter_edges_e : (edge -> unit) -> t -> unit
+
+    val fold_edges_e : (edge -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val map_vertex : (vertex -> vertex) -> t -> t
+
+    val iter_succ : (vertex -> unit) -> t -> vertex -> unit
+
+    val iter_pred : (vertex -> unit) -> t -> vertex -> unit
+
+    val fold_succ : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val fold_pred : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val iter_succ_e : (edge -> unit) -> t -> vertex -> unit
+
+    val fold_succ_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val iter_pred_e : (edge -> unit) -> t -> vertex -> unit
+
+    val fold_pred_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val empty : t
+
+    val add_vertex : t -> vertex -> t
+
+    val remove_vertex : t -> vertex -> t
+
+    val add_edge : t -> vertex -> vertex -> t
+
+    val add_edge_e : t -> edge -> t
+
+    val remove_edge : t -> vertex -> vertex -> t
+
+    val remove_edge_e : t -> edge -> t
+  end
+
+  val history :
+    ?depth:int -> ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
+
+  module Branch : sig
+    val mem : repo -> branch -> bool Lwt.t
+
+    val find : repo -> branch -> commit option Lwt.t
+
+    val get : repo -> branch -> commit Lwt.t
+
+    val set : repo -> branch -> commit -> unit Lwt.t
+
+    val remove : repo -> branch -> unit Lwt.t
+
+    val list : repo -> branch list Lwt.t
+
+    val watch :
+      repo ->
+      branch ->
+      ?init:commit ->
+      (commit Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val watch_all :
+      repo ->
+      ?init:(branch * commit) list ->
+      (branch -> commit Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    type t = branch
+
+    val t : t Irmin.Type.ty
+
+    val master : t
+
+    val is_valid : t -> bool
+  end
+
+  module Key : sig
+    type t = key
+
+    type step = P.step
+
+    val empty : t
+
+    val v : step list -> t
+
+    val is_empty : t -> bool
+
+    val cons : step -> t -> t
+
+    val rcons : t -> step -> t
+
+    val decons : t -> (step * t) option
+
+    val rdecons : t -> (t * step) option
+
+    val map : t -> (step -> 'a) -> 'a list
+
+    val t : t Irmin.Type.ty
+
+    val step_t : step Irmin.Type.ty
+  end
+
+  module Metadata : sig
+    type t = metadata
+
+    val t : t Irmin.Type.ty
+
+    val merge : t Irmin.Merge.t
+
+    val default : t
+  end
+
+  val step_t : step Irmin.Type.ty
+
+  val key_t : key Irmin.Type.ty
+
+  val metadata_t : metadata Irmin.Type.ty
+
+  val contents_t : contents Irmin.Type.ty
+
+  val node_t : node Irmin.Type.ty
+
+  val tree_t : tree Irmin.Type.ty
+
+  val commit_t : repo -> commit Irmin.Type.ty
+
+  val branch_t : branch Irmin.Type.ty
+
+  val slice_t : slice Irmin.Type.ty
+
+  val kind_t : [`Contents | `Node] Irmin.Type.ty
+
+  val lca_error_t : lca_error Irmin.Type.ty
+
+  val ff_error_t : ff_error Irmin.Type.ty
+
+  module Private : sig
+    module Contents : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Contents.t
+
+      type key = Contents.hash
+
+      type value = contents
+
       val mem : t -> key -> bool Lwt.t
+
       val find : t -> key -> value option Lwt.t
-      module Stor : Wodan.S
-      val db_root : t -> Stor.root
-      val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      val merge : t -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : string -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Val : sig
+        type t = value
+
+        val t : t Irmin.Type.ty
+
+        val merge : t option Irmin.Merge.t
+      end
+    end
+
+    module Node : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.t
+
+      type key = Contents.key
+
+      type value = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.value
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      module Path : sig
+        type t = Key.t
+
+        type step = Key.step
+
+        val empty : t
+
+        val v : step list -> t
+
+        val is_empty : t -> bool
+
+        val cons : step -> t -> t
+
+        val rcons : t -> step -> t
+
+        val decons : t -> (step * t) option
+
+        val rdecons : t -> (t * step) option
+
+        val map : t -> (step -> 'a) -> 'a list
+
+        val t : t Irmin.Type.ty
+
+        val step_t : step Irmin.Type.ty
+      end
+
+      val merge : t -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : string -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Metadata : sig
+        type t = metadata
+
+        val t : t Irmin.Type.ty
+
+        val merge : t Irmin.Merge.t
+
+        val default : t
+      end
+
+      module Val : sig
+        type t = value
+
+        type metadata = Metadata.t
+
+        type contents = key
+
+        type node = contents
+
+        type step = Path.step
+
+        type value =
+          [ `Contents of node * metadata
+          | `Node of node ]
+
+        val v : (step * value) list -> t
+
+        val list : t -> (step * value) list
+
+        val empty : t
+
+        val is_empty : t -> bool
+
+        val find : t -> step -> value option
+
+        val update : t -> step -> value -> t
+
+        val remove : t -> step -> t
+
+        val t : t Irmin.Type.ty
+
+        val metadata_t : metadata Irmin.Type.ty
+
+        val contents_t : node Irmin.Type.ty
+
+        val node_t : node Irmin.Type.ty
+
+        val step_t : step Irmin.Type.ty
+
+        val value_t : value Irmin.Type.ty
+      end
+
+      module Contents : sig
+        type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.Contents.t
+
+        type key = Val.node
+
+        type value =
+          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.Contents.value
+
+        val mem : t -> key -> bool Lwt.t
+
+        val find : t -> key -> value option Lwt.t
+
+        val add : t -> value -> key Lwt.t
+
+        val merge : t -> key option Irmin.Merge.t
+
+        module Key : sig
+          type t = key
+
+          val digest : string -> t
+
+          val hash : t -> int
+
+          val digest_size : int
+
+          val t : t Irmin.Type.ty
+        end
+
+        module Val : sig
+          type t = value
+
+          val t : t Irmin.Type.ty
+
+          val merge : t option Irmin.Merge.t
+        end
+      end
+    end
+
+    module Commit : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.t
+
+      type key = Node.key
+
+      type value = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.value
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      val merge : t -> info:Irmin.Info.f -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : string -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Val : sig
+        type t = value
+
+        type commit = key
+
+        type node = commit
+
+        val v : info:Irmin.Info.t -> node:node -> parents:node list -> t
+
+        val node : t -> node
+
+        val parents : t -> node list
+
+        val info : t -> Irmin.Info.t
+
+        val t : t Irmin.Type.ty
+
+        val commit_t : node Irmin.Type.ty
+
+        val node_t : node Irmin.Type.ty
+      end
+
+      module Node : sig
+        type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.t
+
+        type key = Val.node
+
+        type value =
+          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.value
+
+        val mem : t -> key -> bool Lwt.t
+
+        val find : t -> key -> value option Lwt.t
+
+        val add : t -> value -> key Lwt.t
+
+        module Path : sig
+          type t =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Path.t
+
+          type step =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Path.step
+
+          val empty : t
+
+          val v : step list -> t
+
+          val is_empty : t -> bool
+
+          val cons : step -> t -> t
+
+          val rcons : t -> step -> t
+
+          val decons : t -> (step * t) option
+
+          val rdecons : t -> (t * step) option
+
+          val map : t -> (step -> 'a) -> 'a list
+
+          val t : t Irmin.Type.ty
+
+          val step_t : step Irmin.Type.ty
+        end
+
+        val merge : t -> key option Irmin.Merge.t
+
+        module Key : sig
+          type t = key
+
+          val digest : string -> t
+
+          val hash : t -> int
+
+          val digest_size : int
+
+          val t : t Irmin.Type.ty
+        end
+
+        module Metadata : sig
+          type t =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Metadata.t
+
+          val t : t Irmin.Type.ty
+
+          val merge : t Irmin.Merge.t
+
+          val default : t
+        end
+
+        module Val : sig
+          type t = value
+
+          type metadata = Metadata.t
+
+          type contents =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Val.contents
+
+          type node = key
+
+          type step = Path.step
+
+          type value =
+            [ `Contents of contents * metadata
+            | `Node of node ]
+
+          val v : (step * value) list -> t
+
+          val list : t -> (step * value) list
+
+          val empty : t
+
+          val is_empty : t -> bool
+
+          val find : t -> step -> value option
+
+          val update : t -> step -> value -> t
+
+          val remove : t -> step -> t
+
+          val t : t Irmin.Type.ty
+
+          val metadata_t : metadata Irmin.Type.ty
+
+          val contents_t : contents Irmin.Type.ty
+
+          val node_t : node Irmin.Type.ty
+
+          val step_t : step Irmin.Type.ty
+
+          val value_t : value Irmin.Type.ty
+        end
+
+        module Contents : sig
+          type t =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Contents.t
+
+          type key = Val.contents
+
+          type value =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Contents
+            .value
+
+          val mem : t -> key -> bool Lwt.t
+
+          val find : t -> key -> value option Lwt.t
+
+          val add : t -> value -> key Lwt.t
+
+          val merge : t -> key option Irmin.Merge.t
+
+          module Key : sig
+            type t = key
+
+            val digest : string -> t
+
+            val hash : t -> int
+
+            val digest_size : int
+
+            val t : t Irmin.Type.ty
+          end
+
+          module Val : sig
+            type t = value
+
+            val t : t Irmin.Type.ty
+
+            val merge : t option Irmin.Merge.t
+          end
+        end
+      end
+    end
+
+    module Branch : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Branch.t
+
+      type key = branch
+
+      type value = Commit.key
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val set : t -> key -> value -> unit Lwt.t
+
+      val test_and_set :
+        t -> key -> test:value option -> set:value option -> bool Lwt.t
+
+      val remove : t -> key -> unit Lwt.t
+
+      type watch = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Branch.watch
+
+      val watch :
+        t ->
+        ?init:(key * value) list ->
+        (key -> value Irmin.diff -> unit Lwt.t) ->
+        watch Lwt.t
+
+      val watch_key :
+        t ->
+        key ->
+        ?init:value ->
+        (value Irmin.diff -> unit Lwt.t) ->
+        watch Lwt.t
+
+      val unwatch : t -> watch -> unit Lwt.t
+
+      val list : t -> key list Lwt.t
+
+      module Key : sig
+        type t = key
+
+        val t : t Irmin.Type.ty
+
+        val master : t
+
+        val is_valid : t -> bool
+      end
+
+      module Val : sig
+        type t = value
+
+        val digest : string -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+    end
+
+    module Slice : sig
+      type t = slice
+
+      type contents = Branch.value * Contents.value
+
+      type node = Branch.value * Node.value
+
+      type commit = Branch.value * Commit.value
+
+      type value =
+        [ `Commit of commit
+        | `Contents of contents
+        | `Node of node ]
+
+      val empty : unit -> t Lwt.t
+
+      val add : t -> value -> unit Lwt.t
+
+      val iter : t -> (value -> unit Lwt.t) -> unit Lwt.t
+
+      val t : t Irmin.Type.ty
+
+      val contents_t : contents Irmin.Type.ty
+
+      val node_t : node Irmin.Type.ty
+
+      val commit_t : commit Irmin.Type.ty
+
+      val value_t : value Irmin.Type.ty
+    end
+
+    module Repo : sig
+      type t = repo
+
       val v : Irmin.config -> t Lwt.t
-      val flush : t -> int64 Lwt.t
+
+      val contents_t : t -> Contents.t
+
+      val node_t : t -> Node.t
+
+      val commit_t : t -> Commit.t
+
+      val branch_t : t -> Branch.t
     end
-module AO_BUILDER : DB -> Irmin.AO_MAKER
-module LINK_BUILDER : DB -> Irmin.LINK_MAKER
-module RW_BUILDER : DB -> Irmin.Hash.S -> Irmin.RW_MAKER
-module Make :
-  functor
-    (DB : DB) (M : Irmin.Metadata.S) (C : Irmin.Contents.S) (P : Irmin.Path.S) (B : Irmin.Branch.S) (H : Irmin.Hash.S) ->
-    sig
-      module DB :
-        sig
-          module Stor : Wodan.S
-          type t = DB.t
-          val db_root : t -> Stor.root
-          val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-          val v : Irmin.config -> t Lwt.t
-          val flush : t -> int64 Lwt.t
-        end
-      module AO :
-        functor (K : Irmin.Hash.S) (V : Irmin.Type.S) ->
-          sig
-            type t = AO_BUILDER(DB)(K)(V).t
-            type key = K.t
-            type value = V.t
-            val mem : t -> key -> bool Lwt.t
-            val find : t -> key -> value option Lwt.t
-            val add : t -> value -> key Lwt.t
-            val v : Irmin.config -> t Lwt.t
-          end
-      module RW :
-        functor (K : Irmin.Type.S) (V : Irmin.Type.S) ->
-          sig
-            type t = RW_BUILDER(DB)(H)(K)(V).t
-            type key = K.t
-            type value = V.t
-            val mem : t -> key -> bool Lwt.t
-            val find : t -> key -> value option Lwt.t
-            val set : t -> key -> value -> unit Lwt.t
-            val test_and_set :
-              t -> key -> test:value option -> set:value option -> bool Lwt.t
-            val remove : t -> key -> unit Lwt.t
-            val list : t -> key list Lwt.t
-            type watch = RW_BUILDER(DB)(H)(K)(V).watch
-            val watch :
-              t ->
-              ?init:(key * value) list ->
-              (key -> value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-            val watch_key :
-              t ->
-              key ->
-              ?init:value -> (value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-            val unwatch : t -> watch -> unit Lwt.t
-            val v : Irmin.config -> t Lwt.t
-          end
-      type repo = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).repo
-      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).t
-      type step = P.step
-      type key = P.t
-      type metadata = M.t
-      type contents = C.t
-      type node = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).node
-      type tree = [ `Contents of contents * metadata | `Node of node ]
-      type commit = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).commit
-      type branch = B.t
-      type slice = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).slice
-      type lca_error = [ `Max_depth_reached | `Too_many_lcas ]
-      type ff_error =
-          [ `Max_depth_reached | `No_change | `Rejected | `Too_many_lcas ]
-      module Repo :
-        sig
-          type t = repo
-          val v : Irmin.config -> t Lwt.t
-          val heads : t -> commit list Lwt.t
-          val branches : t -> branch list Lwt.t
-          val export :
-            ?full:bool ->
-            ?depth:int ->
-            ?min:commit list -> ?max:commit list -> t -> slice Lwt.t
-          val import : t -> slice -> (unit, [ `Msg of string ]) result Lwt.t
-        end
-      val empty : repo -> t Lwt.t
-      val master : repo -> t Lwt.t
-      val of_branch : repo -> branch -> t Lwt.t
-      val of_commit : commit -> t Lwt.t
-      val repo : t -> repo
-      val tree : t -> tree Lwt.t
-      module Status :
-        sig
-          type t = [ `Branch of branch | `Commit of commit | `Empty ]
-          val t : repo -> t Irmin.Type.ty
-          val pp : t Fmt.t
-        end
-      val status : t -> Status.t
-      module Head :
-        sig
-          val list : repo -> commit list Lwt.t
-          val find : t -> commit option Lwt.t
-          val get : t -> commit Lwt.t
-          val set : t -> commit -> unit Lwt.t
-          val fast_forward :
-            t ->
-            ?max_depth:int ->
-            ?n:int ->
-            commit ->
-            (unit,
-             [ `Max_depth_reached | `No_change | `Rejected | `Too_many_lcas ])
-            result Lwt.t
-          val test_and_set :
-            t -> test:commit option -> set:commit option -> bool Lwt.t
-          val merge :
-            into:t ->
-            info:Irmin.Info.f ->
-            ?max_depth:int ->
-            ?n:int -> commit -> (unit, Irmin.Merge.conflict) result Lwt.t
-        end
-      module Commit :
-        sig
-          type t = commit
-          val t : repo -> t Irmin.Type.ty
-          val pp_hash : t Fmt.t
-          val v :
-            repo -> info:Irmin.Info.t -> parents:t list -> tree -> t Lwt.t
-          val tree : t -> tree Lwt.t
-          val parents : t -> t list Lwt.t
-          val info : t -> Irmin.Info.t
-          module Hash :
-            sig
-              type t = H.t
-              val digest : string -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = Hash.t
-          val hash : t -> hash
-          val of_hash : repo -> hash -> t option Lwt.t
-        end
-      module Contents :
-        sig
-          type t = contents
-          val t : t Irmin.Type.ty
-          val merge : t option Irmin.Merge.t
-          module Hash :
-            sig
-              type t = Commit.hash
-              val digest : string -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = Hash.t
-          val hash : repo -> t -> hash Lwt.t
-          val of_hash : repo -> hash -> t option Lwt.t
-        end
-      module Tree :
-        sig
-          val empty : tree
-          val of_contents : ?metadata:metadata -> contents -> tree
-          val of_node : node -> tree
-          val kind : tree -> key -> [ `Contents | `Node ] option Lwt.t
-          val list : tree -> key -> (step * [ `Contents | `Node ]) list Lwt.t
-          val diff :
-            tree ->
-            tree -> (key * (contents * metadata) Irmin.diff) list Lwt.t
-          val mem : tree -> key -> bool Lwt.t
-          val find_all : tree -> key -> (contents * metadata) option Lwt.t
-          val find : tree -> key -> contents option Lwt.t
-          val get_all : tree -> key -> (contents * metadata) Lwt.t
-          val get : tree -> key -> contents Lwt.t
-          val add :
-            tree -> key -> ?metadata:metadata -> contents -> tree Lwt.t
-          val remove : tree -> key -> tree Lwt.t
-          val mem_tree : tree -> key -> bool Lwt.t
-          val find_tree : tree -> key -> tree option Lwt.t
-          val get_tree : tree -> key -> tree Lwt.t
-          val add_tree : tree -> key -> tree -> tree Lwt.t
-          val merge : tree Irmin.Merge.t
-          val clear_caches : tree -> unit
-          type marks = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Tree.marks
-          val empty_marks : unit -> marks
-          type 'a force = [ `False of key -> 'a -> 'a Lwt.t | `True ]
-          type uniq = [ `False | `Marks of marks | `True ]
-          type 'a node_fn = key -> step list -> 'a -> 'a Lwt.t
-          val fold :
-            ?force:'a force ->
-            ?uniq:uniq ->
-            ?pre:'a node_fn ->
-            ?post:'a node_fn ->
-            (key -> contents -> 'a -> 'a Lwt.t) -> tree -> 'a -> 'a Lwt.t
-          type stats =
-            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Tree.stats = {
-            nodes : int;
-            leafs : int;
-            skips : int;
-            depth : int;
-            width : int;
-          }
-          val pp_stats : stats Fmt.t
-          val stats : ?force:bool -> tree -> stats Lwt.t
-          type concrete =
-              [ `Contents of contents * metadata
-              | `Tree of (step * concrete) list ]
-          val of_concrete : concrete -> tree
-          val to_concrete : tree -> concrete Lwt.t
-          module Hash :
-            sig
-              type t = Contents.hash
-              val digest : string -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = [ `Contents of Hash.t * metadata | `Node of Hash.t ]
-          val hash_t : hash Irmin.Type.ty
-          val hash : repo -> tree -> hash Lwt.t
-          val of_hash : repo -> hash -> tree option Lwt.t
-        end
-      val kind : t -> key -> [ `Contents | `Node ] option Lwt.t
-      val list : t -> key -> (step * [ `Contents | `Node ]) list Lwt.t
-      val mem : t -> key -> bool Lwt.t
-      val mem_tree : t -> key -> bool Lwt.t
-      val find_all : t -> key -> (contents * metadata) option Lwt.t
-      val find : t -> key -> contents option Lwt.t
-      val get_all : t -> key -> (contents * metadata) Lwt.t
-      val get : t -> key -> contents Lwt.t
-      val find_tree : t -> key -> tree option Lwt.t
-      val get_tree : t -> key -> tree Lwt.t
-      type 'a transaction =
-          ?retries:int ->
-          ?allow_empty:bool ->
-          ?strategy:[ `Merge_with_parent of commit | `Set | `Test_and_set ] ->
-          info:Irmin.Info.f -> 'a -> unit Lwt.t
-      val with_tree :
-        t -> key -> (tree option -> tree option Lwt.t) transaction
-      val set : t -> key -> ?metadata:metadata -> contents transaction
-      val set_tree : t -> key -> tree transaction
-      val remove : t -> key transaction
-      val clone : src:t -> dst:branch -> t Lwt.t
-      type watch = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).watch
-      val watch :
-        t -> ?init:commit -> (commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-      val watch_key :
+
+    module Sync : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Sync.t
+
+      type commit = Branch.value
+
+      type branch = Branch.key
+
+      type endpoint = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Sync.endpoint
+
+      val fetch :
         t ->
-        key ->
-        ?init:commit ->
-        ((commit * tree) Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-      val unwatch : watch -> unit Lwt.t
-      type 'a merge =
-          info:Irmin.Info.f ->
-          ?max_depth:int ->
-          ?n:int -> 'a -> (unit, Irmin.Merge.conflict) result Lwt.t
-      val merge : into:t -> t merge
-      val merge_with_branch : t -> branch merge
-      val merge_with_commit : t -> commit merge
-      val lcas :
-        ?max_depth:int ->
-        ?n:int -> t -> t -> (commit list, lca_error) result Lwt.t
-      val lcas_with_branch :
-        t ->
-        ?max_depth:int ->
-        ?n:int -> branch -> (commit list, lca_error) result Lwt.t
-      val lcas_with_commit :
-        t ->
-        ?max_depth:int ->
-        ?n:int -> commit -> (commit list, lca_error) result Lwt.t
-      module History :
-        sig
-          type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.t
-          module V :
-            sig
-              type t = commit
-              val compare : t -> t -> int
-              val hash : t -> int
-              val equal : t -> t -> bool
-              type label = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.V.label
-              val create : label -> t
-              val label : t -> label
-            end
-          type vertex = commit
-          module E :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.E.t
-              val compare : t -> t -> int
-              type vertex = commit
-              val src : t -> vertex
-              val dst : t -> vertex
-              type label = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.E.label
-              val create : vertex -> label -> vertex -> t
-              val label : t -> label
-            end
-          type edge = E.t
-          val is_directed : bool
-          val is_empty : t -> bool
-          val nb_vertex : t -> int
-          val nb_edges : t -> int
-          val out_degree : t -> vertex -> int
-          val in_degree : t -> vertex -> int
-          val mem_vertex : t -> vertex -> bool
-          val mem_edge : t -> vertex -> vertex -> bool
-          val mem_edge_e : t -> edge -> bool
-          val find_edge : t -> vertex -> vertex -> edge
-          val find_all_edges : t -> vertex -> vertex -> edge list
-          val succ : t -> vertex -> vertex list
-          val pred : t -> vertex -> vertex list
-          val succ_e : t -> vertex -> edge list
-          val pred_e : t -> vertex -> edge list
-          val iter_vertex : (vertex -> unit) -> t -> unit
-          val fold_vertex : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
-          val iter_edges : (vertex -> vertex -> unit) -> t -> unit
-          val fold_edges : (vertex -> vertex -> 'a -> 'a) -> t -> 'a -> 'a
-          val iter_edges_e : (edge -> unit) -> t -> unit
-          val fold_edges_e : (edge -> 'a -> 'a) -> t -> 'a -> 'a
-          val map_vertex : (vertex -> vertex) -> t -> t
-          val iter_succ : (vertex -> unit) -> t -> vertex -> unit
-          val iter_pred : (vertex -> unit) -> t -> vertex -> unit
-          val fold_succ : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val fold_pred : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val iter_succ_e : (edge -> unit) -> t -> vertex -> unit
-          val fold_succ_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val iter_pred_e : (edge -> unit) -> t -> vertex -> unit
-          val fold_pred_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val empty : t
-          val add_vertex : t -> vertex -> t
-          val remove_vertex : t -> vertex -> t
-          val add_edge : t -> vertex -> vertex -> t
-          val add_edge_e : t -> edge -> t
-          val remove_edge : t -> vertex -> vertex -> t
-          val remove_edge_e : t -> edge -> t
-        end
-      val history :
         ?depth:int ->
-        ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
-      module Branch :
-        sig
-          val mem : repo -> branch -> bool Lwt.t
-          val find : repo -> branch -> commit option Lwt.t
-          val get : repo -> branch -> commit Lwt.t
-          val set : repo -> branch -> commit -> unit Lwt.t
-          val remove : repo -> branch -> unit Lwt.t
-          val list : repo -> branch list Lwt.t
-          val watch :
-            repo ->
-            branch ->
-            ?init:commit -> (commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-          val watch_all :
-            repo ->
-            ?init:(branch * commit) list ->
-            (branch -> commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-          type t = branch
-          val t : t Irmin.Type.ty
-          val master : t
-          val is_valid : t -> bool
-        end
-      module Key :
-        sig
-          type t = key
-          type step = P.step
-          val empty : t
-          val v : step list -> t
-          val is_empty : t -> bool
-          val cons : step -> t -> t
-          val rcons : t -> step -> t
-          val decons : t -> (step * t) option
-          val rdecons : t -> (t * step) option
-          val map : t -> (step -> 'a) -> 'a list
-          val t : t Irmin.Type.ty
-          val step_t : step Irmin.Type.ty
-        end
-      module Metadata :
-        sig
-          type t = metadata
-          val t : t Irmin.Type.ty
-          val merge : t Irmin.Merge.t
-          val default : t
-        end
-      val step_t : step Irmin.Type.ty
-      val key_t : key Irmin.Type.ty
-      val metadata_t : metadata Irmin.Type.ty
-      val contents_t : contents Irmin.Type.ty
-      val node_t : node Irmin.Type.ty
-      val tree_t : tree Irmin.Type.ty
-      val commit_t : repo -> commit Irmin.Type.ty
-      val branch_t : branch Irmin.Type.ty
-      val slice_t : slice Irmin.Type.ty
-      val kind_t : [ `Contents | `Node ] Irmin.Type.ty
-      val lca_error_t : lca_error Irmin.Type.ty
-      val ff_error_t : ff_error Irmin.Type.ty
-      module Private :
-        sig
-          module Contents :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Contents.t
-              type key = Contents.hash
-              type value = contents
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              val merge : t -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : string -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Val :
-                sig
-                  type t = value
-                  val t : t Irmin.Type.ty
-                  val merge : t option Irmin.Merge.t
-                end
-            end
-          module Node :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.t
-              type key = Contents.key
-              type value =
-                  Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.value
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              module Path :
-                sig
-                  type t = Key.t
-                  type step = Key.step
-                  val empty : t
-                  val v : step list -> t
-                  val is_empty : t -> bool
-                  val cons : step -> t -> t
-                  val rcons : t -> step -> t
-                  val decons : t -> (step * t) option
-                  val rdecons : t -> (t * step) option
-                  val map : t -> (step -> 'a) -> 'a list
-                  val t : t Irmin.Type.ty
-                  val step_t : step Irmin.Type.ty
-                end
-              val merge : t -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : string -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Metadata :
-                sig
-                  type t = metadata
-                  val t : t Irmin.Type.ty
-                  val merge : t Irmin.Merge.t
-                  val default : t
-                end
-              module Val :
-                sig
-                  type t = value
-                  type metadata = Metadata.t
-                  type contents = key
-                  type node = contents
-                  type step = Path.step
-                  type value =
-                      [ `Contents of node * metadata | `Node of node ]
-                  val v : (step * value) list -> t
-                  val list : t -> (step * value) list
-                  val empty : t
-                  val is_empty : t -> bool
-                  val find : t -> step -> value option
-                  val update : t -> step -> value -> t
-                  val remove : t -> step -> t
-                  val t : t Irmin.Type.ty
-                  val metadata_t : metadata Irmin.Type.ty
-                  val contents_t : node Irmin.Type.ty
-                  val node_t : node Irmin.Type.ty
-                  val step_t : step Irmin.Type.ty
-                  val value_t : value Irmin.Type.ty
-                end
-              module Contents :
-                sig
-                  type t =
-                      Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.Contents.t
-                  type key = Val.node
-                  type value =
-                      Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.Contents.value
-                  val mem : t -> key -> bool Lwt.t
-                  val find : t -> key -> value option Lwt.t
-                  val add : t -> value -> key Lwt.t
-                  val merge : t -> key option Irmin.Merge.t
-                  module Key :
-                    sig
-                      type t = key
-                      val digest : string -> t
-                      val hash : t -> int
-                      val digest_size : int
-                      val t : t Irmin.Type.ty
-                    end
-                  module Val :
-                    sig
-                      type t = value
-                      val t : t Irmin.Type.ty
-                      val merge : t option Irmin.Merge.t
-                    end
-                end
-            end
-          module Commit :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.t
-              type key = Node.key
-              type value =
-                  Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.value
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              val merge : t -> info:Irmin.Info.f -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : string -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Val :
-                sig
-                  type t = value
-                  type commit = key
-                  type node = commit
-                  val v :
-                    info:Irmin.Info.t -> node:node -> parents:node list -> t
-                  val node : t -> node
-                  val parents : t -> node list
-                  val info : t -> Irmin.Info.t
-                  val t : t Irmin.Type.ty
-                  val commit_t : node Irmin.Type.ty
-                  val node_t : node Irmin.Type.ty
-                end
-              module Node :
-                sig
-                  type t =
-                      Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.t
-                  type key = Val.node
-                  type value =
-                      Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.value
-                  val mem : t -> key -> bool Lwt.t
-                  val find : t -> key -> value option Lwt.t
-                  val add : t -> value -> key Lwt.t
-                  module Path :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Path.t
-                      type step =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Path.step
-                      val empty : t
-                      val v : step list -> t
-                      val is_empty : t -> bool
-                      val cons : step -> t -> t
-                      val rcons : t -> step -> t
-                      val decons : t -> (step * t) option
-                      val rdecons : t -> (t * step) option
-                      val map : t -> (step -> 'a) -> 'a list
-                      val t : t Irmin.Type.ty
-                      val step_t : step Irmin.Type.ty
-                    end
-                  val merge : t -> key option Irmin.Merge.t
-                  module Key :
-                    sig
-                      type t = key
-                      val digest : string -> t
-                      val hash : t -> int
-                      val digest_size : int
-                      val t : t Irmin.Type.ty
-                    end
-                  module Metadata :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Metadata.t
-                      val t : t Irmin.Type.ty
-                      val merge : t Irmin.Merge.t
-                      val default : t
-                    end
-                  module Val :
-                    sig
-                      type t = value
-                      type metadata = Metadata.t
-                      type contents =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Val.contents
-                      type node = key
-                      type step = Path.step
-                      type value =
-                          [ `Contents of contents * metadata | `Node of node ]
-                      val v : (step * value) list -> t
-                      val list : t -> (step * value) list
-                      val empty : t
-                      val is_empty : t -> bool
-                      val find : t -> step -> value option
-                      val update : t -> step -> value -> t
-                      val remove : t -> step -> t
-                      val t : t Irmin.Type.ty
-                      val metadata_t : metadata Irmin.Type.ty
-                      val contents_t : contents Irmin.Type.ty
-                      val node_t : node Irmin.Type.ty
-                      val step_t : step Irmin.Type.ty
-                      val value_t : value Irmin.Type.ty
-                    end
-                  module Contents :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Contents.t
-                      type key = Val.contents
-                      type value =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Contents.value
-                      val mem : t -> key -> bool Lwt.t
-                      val find : t -> key -> value option Lwt.t
-                      val add : t -> value -> key Lwt.t
-                      val merge : t -> key option Irmin.Merge.t
-                      module Key :
-                        sig
-                          type t = key
-                          val digest : string -> t
-                          val hash : t -> int
-                          val digest_size : int
-                          val t : t Irmin.Type.ty
-                        end
-                      module Val :
-                        sig
-                          type t = value
-                          val t : t Irmin.Type.ty
-                          val merge : t option Irmin.Merge.t
-                        end
-                    end
-                end
-            end
-          module Branch :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Branch.t
-              type key = branch
-              type value = Commit.key
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val set : t -> key -> value -> unit Lwt.t
-              val test_and_set :
-                t ->
-                key -> test:value option -> set:value option -> bool Lwt.t
-              val remove : t -> key -> unit Lwt.t
-              type watch =
-                  Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Branch.watch
-              val watch :
-                t ->
-                ?init:(key * value) list ->
-                (key -> value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-              val watch_key :
-                t ->
-                key ->
-                ?init:value ->
-                (value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-              val unwatch : t -> watch -> unit Lwt.t
-              val list : t -> key list Lwt.t
-              module Key :
-                sig
-                  type t = key
-                  val t : t Irmin.Type.ty
-                  val master : t
-                  val is_valid : t -> bool
-                end
-              module Val :
-                sig
-                  type t = value
-                  val digest : string -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-            end
-          module Slice :
-            sig
-              type t = slice
-              type contents = Branch.value * Contents.value
-              type node = Branch.value * Node.value
-              type commit = Branch.value * Commit.value
-              type value =
-                  [ `Commit of commit | `Contents of contents | `Node of node ]
-              val empty : unit -> t Lwt.t
-              val add : t -> value -> unit Lwt.t
-              val iter : t -> (value -> unit Lwt.t) -> unit Lwt.t
-              val t : t Irmin.Type.ty
-              val contents_t : contents Irmin.Type.ty
-              val node_t : node Irmin.Type.ty
-              val commit_t : commit Irmin.Type.ty
-              val value_t : value Irmin.Type.ty
-            end
-          module Repo :
-            sig
-              type t = repo
-              val v : Irmin.config -> t Lwt.t
-              val contents_t : t -> Contents.t
-              val node_t : t -> Node.t
-              val commit_t : t -> Commit.t
-              val branch_t : t -> Branch.t
-            end
-          module Sync :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Sync.t
-              type commit = Branch.value
-              type branch = Branch.key
-              type endpoint =
-                  Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Sync.endpoint
-              val fetch :
-                t ->
-                ?depth:int ->
-                endpoint ->
-                branch ->
-                (commit, [ `Msg of string | `No_head | `Not_available ])
-                result Lwt.t
-              val push :
-                t ->
-                ?depth:int ->
-                endpoint ->
-                branch ->
-                (unit,
-                 [ `Detached_head
-                 | `Msg of string
-                 | `No_head
-                 | `Not_available ])
-                result Lwt.t
-              val v : repo -> t Lwt.t
-            end
-        end
-      type Irmin.remote += E of Private.Sync.endpoint
-      val flush : DB.t -> int64 Lwt.t
-    end
-module Make_chunked :
-  functor
-    (DB : DB) (M : Irmin.Metadata.S) (C : Irmin.Contents.S) (P : Irmin.Path.S) (B : Irmin.Branch.S) (H : Irmin.Hash.S) ->
-    sig
-      module AO :
-        functor (K : Irmin.Hash.S) (V : Irmin.Type.S) ->
-          sig
-            type t = Irmin_chunk.AO(AO_BUILDER(DB))(K)(V).t
-            type key = K.t
-            type value = V.t
-            val mem : t -> key -> bool Lwt.t
-            val find : t -> key -> value option Lwt.t
-            val add : t -> value -> key Lwt.t
-            val v : Irmin.config -> t Lwt.t
-          end
-      module DB :
-        sig
-          module Stor : Wodan.S
-          type t = DB.t
-          val db_root : t -> Stor.root
-          val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-          val v : Irmin.config -> t Lwt.t
-          val flush : t -> int64 Lwt.t
-        end
-      module RW :
-        functor (K : Irmin.Type.S) (V : Irmin.Type.S) ->
-          sig
-            type t = RW_BUILDER(DB)(H)(K)(V).t
-            type key = K.t
-            type value = V.t
-            val mem : t -> key -> bool Lwt.t
-            val find : t -> key -> value option Lwt.t
-            val set : t -> key -> value -> unit Lwt.t
-            val test_and_set :
-              t -> key -> test:value option -> set:value option -> bool Lwt.t
-            val remove : t -> key -> unit Lwt.t
-            val list : t -> key list Lwt.t
-            type watch = RW_BUILDER(DB)(H)(K)(V).watch
-            val watch :
-              t ->
-              ?init:(key * value) list ->
-              (key -> value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-            val watch_key :
-              t ->
-              key ->
-              ?init:value -> (value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-            val unwatch : t -> watch -> unit Lwt.t
-            val v : Irmin.config -> t Lwt.t
-          end
-      type repo = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).repo
-      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).t
-      type step = P.step
-      type key = P.t
-      type metadata = M.t
-      type contents = C.t
-      type node = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).node
-      type tree = [ `Contents of contents * metadata | `Node of node ]
-      type commit = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).commit
-      type branch = B.t
-      type slice = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).slice
-      type lca_error = [ `Max_depth_reached | `Too_many_lcas ]
-      type ff_error =
-          [ `Max_depth_reached | `No_change | `Rejected | `Too_many_lcas ]
-      module Repo :
-        sig
-          type t = repo
-          val v : Irmin.config -> t Lwt.t
-          val heads : t -> commit list Lwt.t
-          val branches : t -> branch list Lwt.t
-          val export :
-            ?full:bool ->
-            ?depth:int ->
-            ?min:commit list -> ?max:commit list -> t -> slice Lwt.t
-          val import : t -> slice -> (unit, [ `Msg of string ]) result Lwt.t
-        end
-      val empty : repo -> t Lwt.t
-      val master : repo -> t Lwt.t
-      val of_branch : repo -> branch -> t Lwt.t
-      val of_commit : commit -> t Lwt.t
-      val repo : t -> repo
-      val tree : t -> tree Lwt.t
-      module Status :
-        sig
-          type t = [ `Branch of branch | `Commit of commit | `Empty ]
-          val t : repo -> t Irmin.Type.ty
-          val pp : t Fmt.t
-        end
-      val status : t -> Status.t
-      module Head :
-        sig
-          val list : repo -> commit list Lwt.t
-          val find : t -> commit option Lwt.t
-          val get : t -> commit Lwt.t
-          val set : t -> commit -> unit Lwt.t
-          val fast_forward :
-            t ->
-            ?max_depth:int ->
-            ?n:int ->
-            commit ->
-            (unit,
-             [ `Max_depth_reached | `No_change | `Rejected | `Too_many_lcas ])
-            result Lwt.t
-          val test_and_set :
-            t -> test:commit option -> set:commit option -> bool Lwt.t
-          val merge :
-            into:t ->
-            info:Irmin.Info.f ->
-            ?max_depth:int ->
-            ?n:int -> commit -> (unit, Irmin.Merge.conflict) result Lwt.t
-        end
-      module Commit :
-        sig
-          type t = commit
-          val t : repo -> t Irmin.Type.ty
-          val pp_hash : t Fmt.t
-          val v :
-            repo -> info:Irmin.Info.t -> parents:t list -> tree -> t Lwt.t
-          val tree : t -> tree Lwt.t
-          val parents : t -> t list Lwt.t
-          val info : t -> Irmin.Info.t
-          module Hash :
-            sig
-              type t = H.t
-              val digest : string -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = Hash.t
-          val hash : t -> hash
-          val of_hash : repo -> hash -> t option Lwt.t
-        end
-      module Contents :
-        sig
-          type t = contents
-          val t : t Irmin.Type.ty
-          val merge : t option Irmin.Merge.t
-          module Hash :
-            sig
-              type t = Commit.hash
-              val digest : string -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = Hash.t
-          val hash : repo -> t -> hash Lwt.t
-          val of_hash : repo -> hash -> t option Lwt.t
-        end
-      module Tree :
-        sig
-          val empty : tree
-          val of_contents : ?metadata:metadata -> contents -> tree
-          val of_node : node -> tree
-          val kind : tree -> key -> [ `Contents | `Node ] option Lwt.t
-          val list : tree -> key -> (step * [ `Contents | `Node ]) list Lwt.t
-          val diff :
-            tree ->
-            tree -> (key * (contents * metadata) Irmin.diff) list Lwt.t
-          val mem : tree -> key -> bool Lwt.t
-          val find_all : tree -> key -> (contents * metadata) option Lwt.t
-          val find : tree -> key -> contents option Lwt.t
-          val get_all : tree -> key -> (contents * metadata) Lwt.t
-          val get : tree -> key -> contents Lwt.t
-          val add :
-            tree -> key -> ?metadata:metadata -> contents -> tree Lwt.t
-          val remove : tree -> key -> tree Lwt.t
-          val mem_tree : tree -> key -> bool Lwt.t
-          val find_tree : tree -> key -> tree option Lwt.t
-          val get_tree : tree -> key -> tree Lwt.t
-          val add_tree : tree -> key -> tree -> tree Lwt.t
-          val merge : tree Irmin.Merge.t
-          val clear_caches : tree -> unit
-          type marks = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Tree.marks
-          val empty_marks : unit -> marks
-          type 'a force = [ `False of key -> 'a -> 'a Lwt.t | `True ]
-          type uniq = [ `False | `Marks of marks | `True ]
-          type 'a node_fn = key -> step list -> 'a -> 'a Lwt.t
-          val fold :
-            ?force:'a force ->
-            ?uniq:uniq ->
-            ?pre:'a node_fn ->
-            ?post:'a node_fn ->
-            (key -> contents -> 'a -> 'a Lwt.t) -> tree -> 'a -> 'a Lwt.t
-          type stats =
-            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Tree.stats = {
-            nodes : int;
-            leafs : int;
-            skips : int;
-            depth : int;
-            width : int;
-          }
-          val pp_stats : stats Fmt.t
-          val stats : ?force:bool -> tree -> stats Lwt.t
-          type concrete =
-              [ `Contents of contents * metadata
-              | `Tree of (step * concrete) list ]
-          val of_concrete : concrete -> tree
-          val to_concrete : tree -> concrete Lwt.t
-          module Hash :
-            sig
-              type t = Contents.hash
-              val digest : string -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = [ `Contents of Hash.t * metadata | `Node of Hash.t ]
-          val hash_t : hash Irmin.Type.ty
-          val hash : repo -> tree -> hash Lwt.t
-          val of_hash : repo -> hash -> tree option Lwt.t
-        end
-      val kind : t -> key -> [ `Contents | `Node ] option Lwt.t
-      val list : t -> key -> (step * [ `Contents | `Node ]) list Lwt.t
-      val mem : t -> key -> bool Lwt.t
-      val mem_tree : t -> key -> bool Lwt.t
-      val find_all : t -> key -> (contents * metadata) option Lwt.t
-      val find : t -> key -> contents option Lwt.t
-      val get_all : t -> key -> (contents * metadata) Lwt.t
-      val get : t -> key -> contents Lwt.t
-      val find_tree : t -> key -> tree option Lwt.t
-      val get_tree : t -> key -> tree Lwt.t
-      type 'a transaction =
-          ?retries:int ->
-          ?allow_empty:bool ->
-          ?strategy:[ `Merge_with_parent of commit | `Set | `Test_and_set ] ->
-          info:Irmin.Info.f -> 'a -> unit Lwt.t
-      val with_tree :
-        t -> key -> (tree option -> tree option Lwt.t) transaction
-      val set : t -> key -> ?metadata:metadata -> contents transaction
-      val set_tree : t -> key -> tree transaction
-      val remove : t -> key transaction
-      val clone : src:t -> dst:branch -> t Lwt.t
-      type watch = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).watch
-      val watch :
-        t -> ?init:commit -> (commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-      val watch_key :
+        endpoint ->
+        branch ->
+        (commit, [`Msg of string | `No_head | `Not_available]) result Lwt.t
+
+      val push :
         t ->
-        key ->
-        ?init:commit ->
-        ((commit * tree) Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-      val unwatch : watch -> unit Lwt.t
-      type 'a merge =
-          info:Irmin.Info.f ->
-          ?max_depth:int ->
-          ?n:int -> 'a -> (unit, Irmin.Merge.conflict) result Lwt.t
-      val merge : into:t -> t merge
-      val merge_with_branch : t -> branch merge
-      val merge_with_commit : t -> commit merge
-      val lcas :
-        ?max_depth:int ->
-        ?n:int -> t -> t -> (commit list, lca_error) result Lwt.t
-      val lcas_with_branch :
-        t ->
-        ?max_depth:int ->
-        ?n:int -> branch -> (commit list, lca_error) result Lwt.t
-      val lcas_with_commit :
-        t ->
-        ?max_depth:int ->
-        ?n:int -> commit -> (commit list, lca_error) result Lwt.t
-      module History :
-        sig
-          type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.t
-          module V :
-            sig
-              type t = commit
-              val compare : t -> t -> int
-              val hash : t -> int
-              val equal : t -> t -> bool
-              type label = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.V.label
-              val create : label -> t
-              val label : t -> label
-            end
-          type vertex = commit
-          module E :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.E.t
-              val compare : t -> t -> int
-              type vertex = commit
-              val src : t -> vertex
-              val dst : t -> vertex
-              type label = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.E.label
-              val create : vertex -> label -> vertex -> t
-              val label : t -> label
-            end
-          type edge = E.t
-          val is_directed : bool
-          val is_empty : t -> bool
-          val nb_vertex : t -> int
-          val nb_edges : t -> int
-          val out_degree : t -> vertex -> int
-          val in_degree : t -> vertex -> int
-          val mem_vertex : t -> vertex -> bool
-          val mem_edge : t -> vertex -> vertex -> bool
-          val mem_edge_e : t -> edge -> bool
-          val find_edge : t -> vertex -> vertex -> edge
-          val find_all_edges : t -> vertex -> vertex -> edge list
-          val succ : t -> vertex -> vertex list
-          val pred : t -> vertex -> vertex list
-          val succ_e : t -> vertex -> edge list
-          val pred_e : t -> vertex -> edge list
-          val iter_vertex : (vertex -> unit) -> t -> unit
-          val fold_vertex : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
-          val iter_edges : (vertex -> vertex -> unit) -> t -> unit
-          val fold_edges : (vertex -> vertex -> 'a -> 'a) -> t -> 'a -> 'a
-          val iter_edges_e : (edge -> unit) -> t -> unit
-          val fold_edges_e : (edge -> 'a -> 'a) -> t -> 'a -> 'a
-          val map_vertex : (vertex -> vertex) -> t -> t
-          val iter_succ : (vertex -> unit) -> t -> vertex -> unit
-          val iter_pred : (vertex -> unit) -> t -> vertex -> unit
-          val fold_succ : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val fold_pred : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val iter_succ_e : (edge -> unit) -> t -> vertex -> unit
-          val fold_succ_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val iter_pred_e : (edge -> unit) -> t -> vertex -> unit
-          val fold_pred_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val empty : t
-          val add_vertex : t -> vertex -> t
-          val remove_vertex : t -> vertex -> t
-          val add_edge : t -> vertex -> vertex -> t
-          val add_edge_e : t -> edge -> t
-          val remove_edge : t -> vertex -> vertex -> t
-          val remove_edge_e : t -> edge -> t
-        end
-      val history :
         ?depth:int ->
-        ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
-      module Branch :
-        sig
-          val mem : repo -> branch -> bool Lwt.t
-          val find : repo -> branch -> commit option Lwt.t
-          val get : repo -> branch -> commit Lwt.t
-          val set : repo -> branch -> commit -> unit Lwt.t
-          val remove : repo -> branch -> unit Lwt.t
-          val list : repo -> branch list Lwt.t
-          val watch :
-            repo ->
-            branch ->
-            ?init:commit -> (commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-          val watch_all :
-            repo ->
-            ?init:(branch * commit) list ->
-            (branch -> commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-          type t = branch
-          val t : t Irmin.Type.ty
-          val master : t
-          val is_valid : t -> bool
-        end
-      module Key :
-        sig
-          type t = key
-          type step = P.step
-          val empty : t
-          val v : step list -> t
-          val is_empty : t -> bool
-          val cons : step -> t -> t
-          val rcons : t -> step -> t
-          val decons : t -> (step * t) option
-          val rdecons : t -> (t * step) option
-          val map : t -> (step -> 'a) -> 'a list
-          val t : t Irmin.Type.ty
-          val step_t : step Irmin.Type.ty
-        end
-      module Metadata :
-        sig
-          type t = metadata
-          val t : t Irmin.Type.ty
-          val merge : t Irmin.Merge.t
-          val default : t
-        end
-      val step_t : step Irmin.Type.ty
-      val key_t : key Irmin.Type.ty
-      val metadata_t : metadata Irmin.Type.ty
-      val contents_t : contents Irmin.Type.ty
-      val node_t : node Irmin.Type.ty
-      val tree_t : tree Irmin.Type.ty
-      val commit_t : repo -> commit Irmin.Type.ty
-      val branch_t : branch Irmin.Type.ty
-      val slice_t : slice Irmin.Type.ty
-      val kind_t : [ `Contents | `Node ] Irmin.Type.ty
-      val lca_error_t : lca_error Irmin.Type.ty
-      val ff_error_t : ff_error Irmin.Type.ty
-      module Private :
-        sig
-          module Contents :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Contents.t
-              type key = Contents.hash
-              type value = contents
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              val merge : t -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : string -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Val :
-                sig
-                  type t = value
-                  val t : t Irmin.Type.ty
-                  val merge : t option Irmin.Merge.t
-                end
-            end
-          module Node :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.t
-              type key = Contents.key
-              type value =
-                  Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.value
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              module Path :
-                sig
-                  type t = Key.t
-                  type step = Key.step
-                  val empty : t
-                  val v : step list -> t
-                  val is_empty : t -> bool
-                  val cons : step -> t -> t
-                  val rcons : t -> step -> t
-                  val decons : t -> (step * t) option
-                  val rdecons : t -> (t * step) option
-                  val map : t -> (step -> 'a) -> 'a list
-                  val t : t Irmin.Type.ty
-                  val step_t : step Irmin.Type.ty
-                end
-              val merge : t -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : string -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Metadata :
-                sig
-                  type t = metadata
-                  val t : t Irmin.Type.ty
-                  val merge : t Irmin.Merge.t
-                  val default : t
-                end
-              module Val :
-                sig
-                  type t = value
-                  type metadata = Metadata.t
-                  type contents = key
-                  type node = contents
-                  type step = Path.step
-                  type value =
-                      [ `Contents of node * metadata | `Node of node ]
-                  val v : (step * value) list -> t
-                  val list : t -> (step * value) list
-                  val empty : t
-                  val is_empty : t -> bool
-                  val find : t -> step -> value option
-                  val update : t -> step -> value -> t
-                  val remove : t -> step -> t
-                  val t : t Irmin.Type.ty
-                  val metadata_t : metadata Irmin.Type.ty
-                  val contents_t : node Irmin.Type.ty
-                  val node_t : node Irmin.Type.ty
-                  val step_t : step Irmin.Type.ty
-                  val value_t : value Irmin.Type.ty
-                end
-              module Contents :
-                sig
-                  type t =
-                      Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.Contents.t
-                  type key = Val.node
-                  type value =
-                      Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.Contents.value
-                  val mem : t -> key -> bool Lwt.t
-                  val find : t -> key -> value option Lwt.t
-                  val add : t -> value -> key Lwt.t
-                  val merge : t -> key option Irmin.Merge.t
-                  module Key :
-                    sig
-                      type t = key
-                      val digest : string -> t
-                      val hash : t -> int
-                      val digest_size : int
-                      val t : t Irmin.Type.ty
-                    end
-                  module Val :
-                    sig
-                      type t = value
-                      val t : t Irmin.Type.ty
-                      val merge : t option Irmin.Merge.t
-                    end
-                end
-            end
-          module Commit :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.t
-              type key = Node.key
-              type value =
-                  Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.value
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              val merge : t -> info:Irmin.Info.f -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : string -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Val :
-                sig
-                  type t = value
-                  type commit = key
-                  type node = commit
-                  val v :
-                    info:Irmin.Info.t -> node:node -> parents:node list -> t
-                  val node : t -> node
-                  val parents : t -> node list
-                  val info : t -> Irmin.Info.t
-                  val t : t Irmin.Type.ty
-                  val commit_t : node Irmin.Type.ty
-                  val node_t : node Irmin.Type.ty
-                end
-              module Node :
-                sig
-                  type t =
-                      Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.t
-                  type key = Val.node
-                  type value =
-                      Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.value
-                  val mem : t -> key -> bool Lwt.t
-                  val find : t -> key -> value option Lwt.t
-                  val add : t -> value -> key Lwt.t
-                  module Path :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Path.t
-                      type step =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Path.step
-                      val empty : t
-                      val v : step list -> t
-                      val is_empty : t -> bool
-                      val cons : step -> t -> t
-                      val rcons : t -> step -> t
-                      val decons : t -> (step * t) option
-                      val rdecons : t -> (t * step) option
-                      val map : t -> (step -> 'a) -> 'a list
-                      val t : t Irmin.Type.ty
-                      val step_t : step Irmin.Type.ty
-                    end
-                  val merge : t -> key option Irmin.Merge.t
-                  module Key :
-                    sig
-                      type t = key
-                      val digest : string -> t
-                      val hash : t -> int
-                      val digest_size : int
-                      val t : t Irmin.Type.ty
-                    end
-                  module Metadata :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Metadata.t
-                      val t : t Irmin.Type.ty
-                      val merge : t Irmin.Merge.t
-                      val default : t
-                    end
-                  module Val :
-                    sig
-                      type t = value
-                      type metadata = Metadata.t
-                      type contents =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Val.contents
-                      type node = key
-                      type step = Path.step
-                      type value =
-                          [ `Contents of contents * metadata | `Node of node ]
-                      val v : (step * value) list -> t
-                      val list : t -> (step * value) list
-                      val empty : t
-                      val is_empty : t -> bool
-                      val find : t -> step -> value option
-                      val update : t -> step -> value -> t
-                      val remove : t -> step -> t
-                      val t : t Irmin.Type.ty
-                      val metadata_t : metadata Irmin.Type.ty
-                      val contents_t : contents Irmin.Type.ty
-                      val node_t : node Irmin.Type.ty
-                      val step_t : step Irmin.Type.ty
-                      val value_t : value Irmin.Type.ty
-                    end
-                  module Contents :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Contents.t
-                      type key = Val.contents
-                      type value =
-                          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Contents.value
-                      val mem : t -> key -> bool Lwt.t
-                      val find : t -> key -> value option Lwt.t
-                      val add : t -> value -> key Lwt.t
-                      val merge : t -> key option Irmin.Merge.t
-                      module Key :
-                        sig
-                          type t = key
-                          val digest : string -> t
-                          val hash : t -> int
-                          val digest_size : int
-                          val t : t Irmin.Type.ty
-                        end
-                      module Val :
-                        sig
-                          type t = value
-                          val t : t Irmin.Type.ty
-                          val merge : t option Irmin.Merge.t
-                        end
-                    end
-                end
-            end
-          module Branch :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Branch.t
-              type key = branch
-              type value = Commit.key
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val set : t -> key -> value -> unit Lwt.t
-              val test_and_set :
-                t ->
-                key -> test:value option -> set:value option -> bool Lwt.t
-              val remove : t -> key -> unit Lwt.t
-              type watch =
-                  Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Branch.watch
-              val watch :
-                t ->
-                ?init:(key * value) list ->
-                (key -> value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-              val watch_key :
-                t ->
-                key ->
-                ?init:value ->
-                (value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-              val unwatch : t -> watch -> unit Lwt.t
-              val list : t -> key list Lwt.t
-              module Key :
-                sig
-                  type t = key
-                  val t : t Irmin.Type.ty
-                  val master : t
-                  val is_valid : t -> bool
-                end
-              module Val :
-                sig
-                  type t = value
-                  val digest : string -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-            end
-          module Slice :
-            sig
-              type t = slice
-              type contents = Branch.value * Contents.value
-              type node = Branch.value * Node.value
-              type commit = Branch.value * Commit.value
-              type value =
-                  [ `Commit of commit | `Contents of contents | `Node of node ]
-              val empty : unit -> t Lwt.t
-              val add : t -> value -> unit Lwt.t
-              val iter : t -> (value -> unit Lwt.t) -> unit Lwt.t
-              val t : t Irmin.Type.ty
-              val contents_t : contents Irmin.Type.ty
-              val node_t : node Irmin.Type.ty
-              val commit_t : commit Irmin.Type.ty
-              val value_t : value Irmin.Type.ty
-            end
-          module Repo :
-            sig
-              type t = repo
-              val v : Irmin.config -> t Lwt.t
-              val contents_t : t -> Contents.t
-              val node_t : t -> Node.t
-              val commit_t : t -> Commit.t
-              val branch_t : t -> Branch.t
-            end
-          module Sync :
-            sig
-              type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Sync.t
-              type commit = Branch.value
-              type branch = Branch.key
-              type endpoint =
-                  Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Sync.endpoint
-              val fetch :
-                t ->
-                ?depth:int ->
-                endpoint ->
-                branch ->
-                (commit, [ `Msg of string | `No_head | `Not_available ])
-                result Lwt.t
-              val push :
-                t ->
-                ?depth:int ->
-                endpoint ->
-                branch ->
-                (unit,
-                 [ `Detached_head
-                 | `Msg of string
-                 | `No_head
-                 | `Not_available ])
-                result Lwt.t
-              val v : repo -> t Lwt.t
-            end
-        end
-      type Irmin.remote += E of Private.Sync.endpoint
-      val flush : DB.t -> int64 Lwt.t
+        endpoint ->
+        branch ->
+        ( unit,
+          [`Detached_head | `Msg of string | `No_head | `Not_available] )
+        result
+        Lwt.t
+
+      val v : repo -> t Lwt.t
     end
-module KV :
-  functor (DB : DB) (C : Irmin.Contents.S) ->
-    sig
-      module DB :
-        sig
-          module Stor : Wodan.S
-          type t = DB.t
-          val db_root : t -> Stor.root
-          val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-          val v : Irmin.config -> t Lwt.t
-          val flush : t -> int64 Lwt.t
-        end
-      module AO :
-        functor (K : Irmin.Hash.S) (V : Irmin.Type.S) ->
-          sig
-            type t = AO_BUILDER(DB)(K)(V).t
-            type key = K.t
-            type value = V.t
-            val mem : t -> key -> bool Lwt.t
-            val find : t -> key -> value option Lwt.t
-            val add : t -> value -> key Lwt.t
-            val v : Irmin.config -> t Lwt.t
-          end
-      module RW :
-        functor (K : Irmin.Type.S) (V : Irmin.Type.S) ->
-          sig
-            type t = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).t
-            type key = K.t
-            type value = V.t
-            val mem : t -> key -> bool Lwt.t
-            val find : t -> key -> value option Lwt.t
-            val set : t -> key -> value -> unit Lwt.t
-            val test_and_set :
-              t -> key -> test:value option -> set:value option -> bool Lwt.t
-            val remove : t -> key -> unit Lwt.t
-            val list : t -> key list Lwt.t
-            type watch = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).watch
-            val watch :
-              t ->
-              ?init:(key * value) list ->
-              (key -> value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-            val watch_key :
-              t ->
-              key ->
-              ?init:value -> (value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-            val unwatch : t -> watch -> unit Lwt.t
-            val v : Irmin.config -> t Lwt.t
-          end
-      type repo =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).repo
-      type t =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).t
-      type step = string
-      type key = Irmin.Path.String_list.t
-      type metadata = unit
-      type contents = C.t
-      type node =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).node
-      type tree = [ `Contents of contents * metadata | `Node of node ]
-      type commit =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).commit
-      type branch = step
-      type slice =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).slice
-      type lca_error = [ `Max_depth_reached | `Too_many_lcas ]
-      type ff_error =
-          [ `Max_depth_reached | `No_change | `Rejected | `Too_many_lcas ]
-      module Repo :
-        sig
-          type t = repo
-          val v : Irmin.config -> t Lwt.t
-          val heads : t -> commit list Lwt.t
-          val branches : t -> branch list Lwt.t
-          val export :
-            ?full:bool ->
-            ?depth:int ->
-            ?min:commit list -> ?max:commit list -> t -> slice Lwt.t
-          val import :
-            t -> slice -> (metadata, [ `Msg of branch ]) result Lwt.t
-        end
-      val empty : repo -> t Lwt.t
-      val master : repo -> t Lwt.t
-      val of_branch : repo -> branch -> t Lwt.t
-      val of_commit : commit -> t Lwt.t
-      val repo : t -> repo
-      val tree : t -> tree Lwt.t
-      module Status :
-        sig
-          type t = [ `Branch of branch | `Commit of commit | `Empty ]
-          val t : repo -> t Irmin.Type.ty
-          val pp : t Fmt.t
-        end
-      val status : t -> Status.t
-      module Head :
-        sig
-          val list : repo -> commit list Lwt.t
-          val find : t -> commit option Lwt.t
-          val get : t -> commit Lwt.t
-          val set : t -> commit -> metadata Lwt.t
-          val fast_forward :
-            t ->
-            ?max_depth:int ->
-            ?n:int ->
-            commit ->
-            (metadata,
-             [ `Max_depth_reached | `No_change | `Rejected | `Too_many_lcas ])
-            result Lwt.t
-          val test_and_set :
-            t -> test:commit option -> set:commit option -> bool Lwt.t
-          val merge :
-            into:t ->
-            info:Irmin.Info.f ->
-            ?max_depth:int ->
-            ?n:int -> commit -> (metadata, Irmin.Merge.conflict) result Lwt.t
-        end
-      module Commit :
-        sig
-          type t = commit
-          val t : repo -> t Irmin.Type.ty
-          val pp_hash : t Fmt.t
-          val v :
-            repo -> info:Irmin.Info.t -> parents:t list -> tree -> t Lwt.t
-          val tree : t -> tree Lwt.t
-          val parents : t -> t list Lwt.t
-          val info : t -> Irmin.Info.t
-          module Hash :
-            sig
-              type t = Irmin.Hash.SHA1.t
-              val digest : branch -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = Hash.t
-          val hash : t -> hash
-          val of_hash : repo -> hash -> t option Lwt.t
-        end
-      module Contents :
-        sig
-          type t = contents
-          val t : t Irmin.Type.ty
-          val merge : t option Irmin.Merge.t
-          module Hash :
-            sig
-              type t = Commit.hash
-              val digest : branch -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = Hash.t
-          val hash : repo -> t -> hash Lwt.t
-          val of_hash : repo -> hash -> t option Lwt.t
-        end
-      module Tree :
-        sig
-          val empty : tree
-          val of_contents : ?metadata:metadata -> contents -> tree
-          val of_node : node -> tree
-          val kind : tree -> key -> [ `Contents | `Node ] option Lwt.t
-          val list :
-            tree -> key -> (branch * [ `Contents | `Node ]) list Lwt.t
-          val diff :
-            tree ->
-            tree -> (key * (contents * metadata) Irmin.diff) list Lwt.t
-          val mem : tree -> key -> bool Lwt.t
-          val find_all : tree -> key -> (contents * metadata) option Lwt.t
-          val find : tree -> key -> contents option Lwt.t
-          val get_all : tree -> key -> (contents * metadata) Lwt.t
-          val get : tree -> key -> contents Lwt.t
-          val add :
-            tree -> key -> ?metadata:metadata -> contents -> tree Lwt.t
-          val remove : tree -> key -> tree Lwt.t
-          val mem_tree : tree -> key -> bool Lwt.t
-          val find_tree : tree -> key -> tree option Lwt.t
-          val get_tree : tree -> key -> tree Lwt.t
-          val add_tree : tree -> key -> tree -> tree Lwt.t
-          val merge : tree Irmin.Merge.t
-          val clear_caches : tree -> metadata
-          type marks =
-              Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Tree.marks
-          val empty_marks : metadata -> marks
-          type 'a force = [ `False of key -> 'a -> 'a Lwt.t | `True ]
-          type uniq = [ `False | `Marks of marks | `True ]
-          type 'a node_fn = key -> branch list -> 'a -> 'a Lwt.t
-          val fold :
-            ?force:'a force ->
-            ?uniq:uniq ->
-            ?pre:'a node_fn ->
-            ?post:'a node_fn ->
-            (key -> contents -> 'a -> 'a Lwt.t) -> tree -> 'a -> 'a Lwt.t
-          type stats =
-            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Tree.stats = {
-            nodes : int;
-            leafs : int;
-            skips : int;
-            depth : int;
-            width : int;
-          }
-          val pp_stats : stats Fmt.t
-          val stats : ?force:bool -> tree -> stats Lwt.t
-          type concrete =
-              [ `Contents of contents * metadata
-              | `Tree of (branch * concrete) list ]
-          val of_concrete : concrete -> tree
-          val to_concrete : tree -> concrete Lwt.t
-          module Hash :
-            sig
-              type t = Contents.hash
-              val digest : branch -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = [ `Contents of Hash.t * metadata | `Node of Hash.t ]
-          val hash_t : hash Irmin.Type.ty
-          val hash : repo -> tree -> hash Lwt.t
-          val of_hash : repo -> hash -> tree option Lwt.t
-        end
-      val kind : t -> key -> [ `Contents | `Node ] option Lwt.t
-      val list : t -> key -> (branch * [ `Contents | `Node ]) list Lwt.t
+  end
+
+  type Irmin.remote += E of Private.Sync.endpoint
+
+  val flush : DB.t -> int64 Lwt.t
+end
+
+module Make_chunked
+    (DB : DB)
+    (M : Irmin.Metadata.S)
+    (C : Irmin.Contents.S)
+    (P : Irmin.Path.S)
+    (B : Irmin.Branch.S)
+    (H : Irmin.Hash.S) : sig
+  module AO (K : Irmin.Hash.S) (V : Irmin.Type.S) : sig
+    type t = Irmin_chunk.AO(AO_BUILDER(DB))(K)(V).t
+
+    type key = K.t
+
+    type value = V.t
+
+    val mem : t -> key -> bool Lwt.t
+
+    val find : t -> key -> value option Lwt.t
+
+    val add : t -> value -> key Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+  end
+
+  module DB : sig
+    module Stor : Wodan.S
+
+    type t = DB.t
+
+    val db_root : t -> Stor.root
+
+    val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+
+    val flush : t -> int64 Lwt.t
+  end
+
+  module RW (K : Irmin.Type.S) (V : Irmin.Type.S) : sig
+    type t = RW_BUILDER(DB)(H)(K)(V).t
+
+    type key = K.t
+
+    type value = V.t
+
+    val mem : t -> key -> bool Lwt.t
+
+    val find : t -> key -> value option Lwt.t
+
+    val set : t -> key -> value -> unit Lwt.t
+
+    val test_and_set :
+      t -> key -> test:value option -> set:value option -> bool Lwt.t
+
+    val remove : t -> key -> unit Lwt.t
+
+    val list : t -> key list Lwt.t
+
+    type watch = RW_BUILDER(DB)(H)(K)(V).watch
+
+    val watch :
+      t ->
+      ?init:(key * value) list ->
+      (key -> value Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val watch_key :
+      t ->
+      key ->
+      ?init:value ->
+      (value Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val unwatch : t -> watch -> unit Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+  end
+
+  type repo = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).repo
+
+  type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).t
+
+  type step = P.step
+
+  type key = P.t
+
+  type metadata = M.t
+
+  type contents = C.t
+
+  type node = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).node
+
+  type tree =
+    [ `Contents of contents * metadata
+    | `Node of node ]
+
+  type commit = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).commit
+
+  type branch = B.t
+
+  type slice = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).slice
+
+  type lca_error =
+    [ `Max_depth_reached
+    | `Too_many_lcas ]
+
+  type ff_error =
+    [ `Max_depth_reached
+    | `No_change
+    | `Rejected
+    | `Too_many_lcas ]
+
+  module Repo : sig
+    type t = repo
+
+    val v : Irmin.config -> t Lwt.t
+
+    val heads : t -> commit list Lwt.t
+
+    val branches : t -> branch list Lwt.t
+
+    val export :
+      ?full:bool ->
+      ?depth:int ->
+      ?min:commit list ->
+      ?max:commit list ->
+      t ->
+      slice Lwt.t
+
+    val import : t -> slice -> (unit, [`Msg of string]) result Lwt.t
+  end
+
+  val empty : repo -> t Lwt.t
+
+  val master : repo -> t Lwt.t
+
+  val of_branch : repo -> branch -> t Lwt.t
+
+  val of_commit : commit -> t Lwt.t
+
+  val repo : t -> repo
+
+  val tree : t -> tree Lwt.t
+
+  module Status : sig
+    type t =
+      [ `Branch of branch
+      | `Commit of commit
+      | `Empty ]
+
+    val t : repo -> t Irmin.Type.ty
+
+    val pp : t Fmt.t
+  end
+
+  val status : t -> Status.t
+
+  module Head : sig
+    val list : repo -> commit list Lwt.t
+
+    val find : t -> commit option Lwt.t
+
+    val get : t -> commit Lwt.t
+
+    val set : t -> commit -> unit Lwt.t
+
+    val fast_forward :
+      t ->
+      ?max_depth:int ->
+      ?n:int ->
+      commit ->
+      ( unit,
+        [`Max_depth_reached | `No_change | `Rejected | `Too_many_lcas] )
+      result
+      Lwt.t
+
+    val test_and_set :
+      t -> test:commit option -> set:commit option -> bool Lwt.t
+
+    val merge :
+      into:t ->
+      info:Irmin.Info.f ->
+      ?max_depth:int ->
+      ?n:int ->
+      commit ->
+      (unit, Irmin.Merge.conflict) result Lwt.t
+  end
+
+  module Commit : sig
+    type t = commit
+
+    val t : repo -> t Irmin.Type.ty
+
+    val pp_hash : t Fmt.t
+
+    val v : repo -> info:Irmin.Info.t -> parents:t list -> tree -> t Lwt.t
+
+    val tree : t -> tree Lwt.t
+
+    val parents : t -> t list Lwt.t
+
+    val info : t -> Irmin.Info.t
+
+    module Hash : sig
+      type t = H.t
+
+      val digest : string -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash = Hash.t
+
+    val hash : t -> hash
+
+    val of_hash : repo -> hash -> t option Lwt.t
+  end
+
+  module Contents : sig
+    type t = contents
+
+    val t : t Irmin.Type.ty
+
+    val merge : t option Irmin.Merge.t
+
+    module Hash : sig
+      type t = Commit.hash
+
+      val digest : string -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash = Hash.t
+
+    val hash : repo -> t -> hash Lwt.t
+
+    val of_hash : repo -> hash -> t option Lwt.t
+  end
+
+  module Tree : sig
+    val empty : tree
+
+    val of_contents : ?metadata:metadata -> contents -> tree
+
+    val of_node : node -> tree
+
+    val kind : tree -> key -> [`Contents | `Node] option Lwt.t
+
+    val list : tree -> key -> (step * [`Contents | `Node]) list Lwt.t
+
+    val diff :
+      tree -> tree -> (key * (contents * metadata) Irmin.diff) list Lwt.t
+
+    val mem : tree -> key -> bool Lwt.t
+
+    val find_all : tree -> key -> (contents * metadata) option Lwt.t
+
+    val find : tree -> key -> contents option Lwt.t
+
+    val get_all : tree -> key -> (contents * metadata) Lwt.t
+
+    val get : tree -> key -> contents Lwt.t
+
+    val add : tree -> key -> ?metadata:metadata -> contents -> tree Lwt.t
+
+    val remove : tree -> key -> tree Lwt.t
+
+    val mem_tree : tree -> key -> bool Lwt.t
+
+    val find_tree : tree -> key -> tree option Lwt.t
+
+    val get_tree : tree -> key -> tree Lwt.t
+
+    val add_tree : tree -> key -> tree -> tree Lwt.t
+
+    val merge : tree Irmin.Merge.t
+
+    val clear_caches : tree -> unit
+
+    type marks = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Tree.marks
+
+    val empty_marks : unit -> marks
+
+    type 'a force =
+      [ `False of key -> 'a -> 'a Lwt.t
+      | `True ]
+
+    type uniq =
+      [ `False
+      | `Marks of marks
+      | `True ]
+
+    type 'a node_fn = key -> step list -> 'a -> 'a Lwt.t
+
+    val fold :
+      ?force:'a force ->
+      ?uniq:uniq ->
+      ?pre:'a node_fn ->
+      ?post:'a node_fn ->
+      (key -> contents -> 'a -> 'a Lwt.t) ->
+      tree ->
+      'a ->
+      'a Lwt.t
+
+    type stats = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Tree.stats = {
+      nodes : int;
+      leafs : int;
+      skips : int;
+      depth : int;
+      width : int
+    }
+
+    val pp_stats : stats Fmt.t
+
+    val stats : ?force:bool -> tree -> stats Lwt.t
+
+    type concrete =
+      [ `Contents of contents * metadata
+      | `Tree of (step * concrete) list ]
+
+    val of_concrete : concrete -> tree
+
+    val to_concrete : tree -> concrete Lwt.t
+
+    module Hash : sig
+      type t = Contents.hash
+
+      val digest : string -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash =
+      [ `Contents of Hash.t * metadata
+      | `Node of Hash.t ]
+
+    val hash_t : hash Irmin.Type.ty
+
+    val hash : repo -> tree -> hash Lwt.t
+
+    val of_hash : repo -> hash -> tree option Lwt.t
+  end
+
+  val kind : t -> key -> [`Contents | `Node] option Lwt.t
+
+  val list : t -> key -> (step * [`Contents | `Node]) list Lwt.t
+
+  val mem : t -> key -> bool Lwt.t
+
+  val mem_tree : t -> key -> bool Lwt.t
+
+  val find_all : t -> key -> (contents * metadata) option Lwt.t
+
+  val find : t -> key -> contents option Lwt.t
+
+  val get_all : t -> key -> (contents * metadata) Lwt.t
+
+  val get : t -> key -> contents Lwt.t
+
+  val find_tree : t -> key -> tree option Lwt.t
+
+  val get_tree : t -> key -> tree Lwt.t
+
+  type 'a transaction =
+    ?retries:int ->
+    ?allow_empty:bool ->
+    ?strategy:[`Merge_with_parent of commit | `Set | `Test_and_set] ->
+    info:Irmin.Info.f ->
+    'a ->
+    unit Lwt.t
+
+  val with_tree : t -> key -> (tree option -> tree option Lwt.t) transaction
+
+  val set : t -> key -> ?metadata:metadata -> contents transaction
+
+  val set_tree : t -> key -> tree transaction
+
+  val remove : t -> key transaction
+
+  val clone : src:t -> dst:branch -> t Lwt.t
+
+  type watch = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).watch
+
+  val watch :
+    t -> ?init:commit -> (commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
+
+  val watch_key :
+    t ->
+    key ->
+    ?init:commit ->
+    ((commit * tree) Irmin.diff -> unit Lwt.t) ->
+    watch Lwt.t
+
+  val unwatch : watch -> unit Lwt.t
+
+  type 'a merge =
+    info:Irmin.Info.f ->
+    ?max_depth:int ->
+    ?n:int ->
+    'a ->
+    (unit, Irmin.Merge.conflict) result Lwt.t
+
+  val merge : into:t -> t merge
+
+  val merge_with_branch : t -> branch merge
+
+  val merge_with_commit : t -> commit merge
+
+  val lcas :
+    ?max_depth:int ->
+    ?n:int ->
+    t ->
+    t ->
+    (commit list, lca_error) result Lwt.t
+
+  val lcas_with_branch :
+    t ->
+    ?max_depth:int ->
+    ?n:int ->
+    branch ->
+    (commit list, lca_error) result Lwt.t
+
+  val lcas_with_commit :
+    t ->
+    ?max_depth:int ->
+    ?n:int ->
+    commit ->
+    (commit list, lca_error) result Lwt.t
+
+  module History : sig
+    type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.t
+
+    module V : sig
+      type t = commit
+
+      val compare : t -> t -> int
+
+      val hash : t -> int
+
+      val equal : t -> t -> bool
+
+      type label = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.V.label
+
+      val create : label -> t
+
+      val label : t -> label
+    end
+
+    type vertex = commit
+
+    module E : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.E.t
+
+      val compare : t -> t -> int
+
+      type vertex = commit
+
+      val src : t -> vertex
+
+      val dst : t -> vertex
+
+      type label = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).History.E.label
+
+      val create : vertex -> label -> vertex -> t
+
+      val label : t -> label
+    end
+
+    type edge = E.t
+
+    val is_directed : bool
+
+    val is_empty : t -> bool
+
+    val nb_vertex : t -> int
+
+    val nb_edges : t -> int
+
+    val out_degree : t -> vertex -> int
+
+    val in_degree : t -> vertex -> int
+
+    val mem_vertex : t -> vertex -> bool
+
+    val mem_edge : t -> vertex -> vertex -> bool
+
+    val mem_edge_e : t -> edge -> bool
+
+    val find_edge : t -> vertex -> vertex -> edge
+
+    val find_all_edges : t -> vertex -> vertex -> edge list
+
+    val succ : t -> vertex -> vertex list
+
+    val pred : t -> vertex -> vertex list
+
+    val succ_e : t -> vertex -> edge list
+
+    val pred_e : t -> vertex -> edge list
+
+    val iter_vertex : (vertex -> unit) -> t -> unit
+
+    val fold_vertex : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val iter_edges : (vertex -> vertex -> unit) -> t -> unit
+
+    val fold_edges : (vertex -> vertex -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val iter_edges_e : (edge -> unit) -> t -> unit
+
+    val fold_edges_e : (edge -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val map_vertex : (vertex -> vertex) -> t -> t
+
+    val iter_succ : (vertex -> unit) -> t -> vertex -> unit
+
+    val iter_pred : (vertex -> unit) -> t -> vertex -> unit
+
+    val fold_succ : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val fold_pred : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val iter_succ_e : (edge -> unit) -> t -> vertex -> unit
+
+    val fold_succ_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val iter_pred_e : (edge -> unit) -> t -> vertex -> unit
+
+    val fold_pred_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val empty : t
+
+    val add_vertex : t -> vertex -> t
+
+    val remove_vertex : t -> vertex -> t
+
+    val add_edge : t -> vertex -> vertex -> t
+
+    val add_edge_e : t -> edge -> t
+
+    val remove_edge : t -> vertex -> vertex -> t
+
+    val remove_edge_e : t -> edge -> t
+  end
+
+  val history :
+    ?depth:int -> ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
+
+  module Branch : sig
+    val mem : repo -> branch -> bool Lwt.t
+
+    val find : repo -> branch -> commit option Lwt.t
+
+    val get : repo -> branch -> commit Lwt.t
+
+    val set : repo -> branch -> commit -> unit Lwt.t
+
+    val remove : repo -> branch -> unit Lwt.t
+
+    val list : repo -> branch list Lwt.t
+
+    val watch :
+      repo ->
+      branch ->
+      ?init:commit ->
+      (commit Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val watch_all :
+      repo ->
+      ?init:(branch * commit) list ->
+      (branch -> commit Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    type t = branch
+
+    val t : t Irmin.Type.ty
+
+    val master : t
+
+    val is_valid : t -> bool
+  end
+
+  module Key : sig
+    type t = key
+
+    type step = P.step
+
+    val empty : t
+
+    val v : step list -> t
+
+    val is_empty : t -> bool
+
+    val cons : step -> t -> t
+
+    val rcons : t -> step -> t
+
+    val decons : t -> (step * t) option
+
+    val rdecons : t -> (t * step) option
+
+    val map : t -> (step -> 'a) -> 'a list
+
+    val t : t Irmin.Type.ty
+
+    val step_t : step Irmin.Type.ty
+  end
+
+  module Metadata : sig
+    type t = metadata
+
+    val t : t Irmin.Type.ty
+
+    val merge : t Irmin.Merge.t
+
+    val default : t
+  end
+
+  val step_t : step Irmin.Type.ty
+
+  val key_t : key Irmin.Type.ty
+
+  val metadata_t : metadata Irmin.Type.ty
+
+  val contents_t : contents Irmin.Type.ty
+
+  val node_t : node Irmin.Type.ty
+
+  val tree_t : tree Irmin.Type.ty
+
+  val commit_t : repo -> commit Irmin.Type.ty
+
+  val branch_t : branch Irmin.Type.ty
+
+  val slice_t : slice Irmin.Type.ty
+
+  val kind_t : [`Contents | `Node] Irmin.Type.ty
+
+  val lca_error_t : lca_error Irmin.Type.ty
+
+  val ff_error_t : ff_error Irmin.Type.ty
+
+  module Private : sig
+    module Contents : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Contents.t
+
+      type key = Contents.hash
+
+      type value = contents
+
       val mem : t -> key -> bool Lwt.t
-      val mem_tree : t -> key -> bool Lwt.t
-      val find_all : t -> key -> (contents * metadata) option Lwt.t
-      val find : t -> key -> contents option Lwt.t
-      val get_all : t -> key -> (contents * metadata) Lwt.t
-      val get : t -> key -> contents Lwt.t
-      val find_tree : t -> key -> tree option Lwt.t
-      val get_tree : t -> key -> tree Lwt.t
-      type 'a transaction =
-          ?retries:int ->
-          ?allow_empty:bool ->
-          ?strategy:[ `Merge_with_parent of commit | `Set | `Test_and_set ] ->
-          info:Irmin.Info.f -> 'a -> metadata Lwt.t
-      val with_tree :
-        t -> key -> (tree option -> tree option Lwt.t) transaction
-      val set : t -> key -> ?metadata:metadata -> contents transaction
-      val set_tree : t -> key -> tree transaction
-      val remove : t -> key transaction
-      val clone : src:t -> dst:branch -> t Lwt.t
-      type watch =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).watch
-      val watch :
-        t ->
-        ?init:commit -> (commit Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-      val watch_key :
-        t ->
-        key ->
-        ?init:commit ->
-        ((commit * tree) Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-      val unwatch : watch -> metadata Lwt.t
-      type 'a merge =
-          info:Irmin.Info.f ->
-          ?max_depth:int ->
-          ?n:int -> 'a -> (metadata, Irmin.Merge.conflict) result Lwt.t
-      val merge : into:t -> t merge
-      val merge_with_branch : t -> branch merge
-      val merge_with_commit : t -> commit merge
-      val lcas :
-        ?max_depth:int ->
-        ?n:int -> t -> t -> (commit list, lca_error) result Lwt.t
-      val lcas_with_branch :
-        t ->
-        ?max_depth:int ->
-        ?n:int -> branch -> (commit list, lca_error) result Lwt.t
-      val lcas_with_commit :
-        t ->
-        ?max_depth:int ->
-        ?n:int -> commit -> (commit list, lca_error) result Lwt.t
-      module History :
-        sig
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      val merge : t -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : string -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Val : sig
+        type t = value
+
+        val t : t Irmin.Type.ty
+
+        val merge : t option Irmin.Merge.t
+      end
+    end
+
+    module Node : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.t
+
+      type key = Contents.key
+
+      type value = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.value
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      module Path : sig
+        type t = Key.t
+
+        type step = Key.step
+
+        val empty : t
+
+        val v : step list -> t
+
+        val is_empty : t -> bool
+
+        val cons : step -> t -> t
+
+        val rcons : t -> step -> t
+
+        val decons : t -> (step * t) option
+
+        val rdecons : t -> (t * step) option
+
+        val map : t -> (step -> 'a) -> 'a list
+
+        val t : t Irmin.Type.ty
+
+        val step_t : step Irmin.Type.ty
+      end
+
+      val merge : t -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : string -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Metadata : sig
+        type t = metadata
+
+        val t : t Irmin.Type.ty
+
+        val merge : t Irmin.Merge.t
+
+        val default : t
+      end
+
+      module Val : sig
+        type t = value
+
+        type metadata = Metadata.t
+
+        type contents = key
+
+        type node = contents
+
+        type step = Path.step
+
+        type value =
+          [ `Contents of node * metadata
+          | `Node of node ]
+
+        val v : (step * value) list -> t
+
+        val list : t -> (step * value) list
+
+        val empty : t
+
+        val is_empty : t -> bool
+
+        val find : t -> step -> value option
+
+        val update : t -> step -> value -> t
+
+        val remove : t -> step -> t
+
+        val t : t Irmin.Type.ty
+
+        val metadata_t : metadata Irmin.Type.ty
+
+        val contents_t : node Irmin.Type.ty
+
+        val node_t : node Irmin.Type.ty
+
+        val step_t : step Irmin.Type.ty
+
+        val value_t : value Irmin.Type.ty
+      end
+
+      module Contents : sig
+        type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.Contents.t
+
+        type key = Val.node
+
+        type value =
+          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Node.Contents.value
+
+        val mem : t -> key -> bool Lwt.t
+
+        val find : t -> key -> value option Lwt.t
+
+        val add : t -> value -> key Lwt.t
+
+        val merge : t -> key option Irmin.Merge.t
+
+        module Key : sig
+          type t = key
+
+          val digest : string -> t
+
+          val hash : t -> int
+
+          val digest_size : int
+
+          val t : t Irmin.Type.ty
+        end
+
+        module Val : sig
+          type t = value
+
+          val t : t Irmin.Type.ty
+
+          val merge : t option Irmin.Merge.t
+        end
+      end
+    end
+
+    module Commit : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.t
+
+      type key = Node.key
+
+      type value = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.value
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      val merge : t -> info:Irmin.Info.f -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : string -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Val : sig
+        type t = value
+
+        type commit = key
+
+        type node = commit
+
+        val v : info:Irmin.Info.t -> node:node -> parents:node list -> t
+
+        val node : t -> node
+
+        val parents : t -> node list
+
+        val info : t -> Irmin.Info.t
+
+        val t : t Irmin.Type.ty
+
+        val commit_t : node Irmin.Type.ty
+
+        val node_t : node Irmin.Type.ty
+      end
+
+      module Node : sig
+        type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.t
+
+        type key = Val.node
+
+        type value =
+          Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.value
+
+        val mem : t -> key -> bool Lwt.t
+
+        val find : t -> key -> value option Lwt.t
+
+        val add : t -> value -> key Lwt.t
+
+        module Path : sig
           type t =
-              Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).History.t
-          module V :
-            sig
-              type t = commit
-              val compare : t -> t -> int
-              val hash : t -> int
-              val equal : t -> t -> bool
-              type label =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).History.V.label
-              val create : label -> t
-              val label : t -> label
-            end
-          type vertex = commit
-          module E :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).History.E.t
-              val compare : t -> t -> int
-              type vertex = commit
-              val src : t -> vertex
-              val dst : t -> vertex
-              type label =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).History.E.label
-              val create : vertex -> label -> vertex -> t
-              val label : t -> label
-            end
-          type edge = E.t
-          val is_directed : bool
-          val is_empty : t -> bool
-          val nb_vertex : t -> int
-          val nb_edges : t -> int
-          val out_degree : t -> vertex -> int
-          val in_degree : t -> vertex -> int
-          val mem_vertex : t -> vertex -> bool
-          val mem_edge : t -> vertex -> vertex -> bool
-          val mem_edge_e : t -> edge -> bool
-          val find_edge : t -> vertex -> vertex -> edge
-          val find_all_edges : t -> vertex -> vertex -> edge list
-          val succ : t -> vertex -> vertex list
-          val pred : t -> vertex -> vertex list
-          val succ_e : t -> vertex -> edge list
-          val pred_e : t -> vertex -> edge list
-          val iter_vertex : (vertex -> metadata) -> t -> metadata
-          val fold_vertex : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
-          val iter_edges : (vertex -> vertex -> metadata) -> t -> metadata
-          val fold_edges : (vertex -> vertex -> 'a -> 'a) -> t -> 'a -> 'a
-          val iter_edges_e : (edge -> metadata) -> t -> metadata
-          val fold_edges_e : (edge -> 'a -> 'a) -> t -> 'a -> 'a
-          val map_vertex : (vertex -> vertex) -> t -> t
-          val iter_succ : (vertex -> metadata) -> t -> vertex -> metadata
-          val iter_pred : (vertex -> metadata) -> t -> vertex -> metadata
-          val fold_succ : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val fold_pred : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val iter_succ_e : (edge -> metadata) -> t -> vertex -> metadata
-          val fold_succ_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val iter_pred_e : (edge -> metadata) -> t -> vertex -> metadata
-          val fold_pred_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Path.t
+
+          type step =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Path.step
+
           val empty : t
-          val add_vertex : t -> vertex -> t
-          val remove_vertex : t -> vertex -> t
-          val add_edge : t -> vertex -> vertex -> t
-          val add_edge_e : t -> edge -> t
-          val remove_edge : t -> vertex -> vertex -> t
-          val remove_edge_e : t -> edge -> t
-        end
-      val history :
-        ?depth:int ->
-        ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
-      module Branch :
-        sig
-          val mem : repo -> branch -> bool Lwt.t
-          val find : repo -> branch -> commit option Lwt.t
-          val get : repo -> branch -> commit Lwt.t
-          val set : repo -> branch -> commit -> metadata Lwt.t
-          val remove : repo -> branch -> metadata Lwt.t
-          val list : repo -> branch list Lwt.t
-          val watch :
-            repo ->
-            branch ->
-            ?init:commit ->
-            (commit Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-          val watch_all :
-            repo ->
-            ?init:(branch * commit) list ->
-            (branch -> commit Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-          type t = branch
-          val t : t Irmin.Type.ty
-          val master : t
-          val is_valid : t -> bool
-        end
-      module Key :
-        sig
-          type t = key
-          type step = branch
-          val empty : t
+
           val v : step list -> t
+
           val is_empty : t -> bool
+
           val cons : step -> t -> t
+
           val rcons : t -> step -> t
+
           val decons : t -> (step * t) option
+
           val rdecons : t -> (t * step) option
+
           val map : t -> (step -> 'a) -> 'a list
+
           val t : t Irmin.Type.ty
+
           val step_t : step Irmin.Type.ty
         end
-      module Metadata :
-        sig
-          type t = metadata
+
+        val merge : t -> key option Irmin.Merge.t
+
+        module Key : sig
+          type t = key
+
+          val digest : string -> t
+
+          val hash : t -> int
+
+          val digest_size : int
+
           val t : t Irmin.Type.ty
+        end
+
+        module Metadata : sig
+          type t =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Metadata.t
+
+          val t : t Irmin.Type.ty
+
           val merge : t Irmin.Merge.t
+
           val default : t
         end
-      val step_t : branch Irmin.Type.ty
-      val key_t : key Irmin.Type.ty
-      val metadata_t : metadata Irmin.Type.ty
-      val contents_t : contents Irmin.Type.ty
-      val node_t : node Irmin.Type.ty
-      val tree_t : tree Irmin.Type.ty
-      val commit_t : repo -> commit Irmin.Type.ty
-      val branch_t : branch Irmin.Type.ty
-      val slice_t : slice Irmin.Type.ty
-      val kind_t : [ `Contents | `Node ] Irmin.Type.ty
-      val lca_error_t : lca_error Irmin.Type.ty
-      val ff_error_t : ff_error Irmin.Type.ty
-      module Private :
-        sig
-          module Contents :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Contents.t
-              type key = Contents.hash
-              type value = contents
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              val merge : t -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : branch -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Val :
-                sig
-                  type t = value
-                  val t : t Irmin.Type.ty
-                  val merge : t option Irmin.Merge.t
-                end
-            end
-          module Node :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Node.t
-              type key = Contents.key
-              type value =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Node.value
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              module Path :
-                sig
-                  type t = Key.t
-                  type step = branch
-                  val empty : t
-                  val v : step list -> t
-                  val is_empty : t -> bool
-                  val cons : step -> t -> t
-                  val rcons : t -> step -> t
-                  val decons : t -> (step * t) option
-                  val rdecons : t -> (t * step) option
-                  val map : t -> (step -> 'a) -> 'a list
-                  val t : t Irmin.Type.ty
-                  val step_t : step Irmin.Type.ty
-                end
-              val merge : t -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : branch -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Metadata :
-                sig
-                  type t = metadata
-                  val t : t Irmin.Type.ty
-                  val merge : t Irmin.Merge.t
-                  val default : t
-                end
-              module Val :
-                sig
-                  type t = value
-                  type metadata = unit
-                  type contents = key
-                  type node = contents
-                  type step = branch
-                  type value =
-                      [ `Contents of node * metadata | `Node of node ]
-                  val v : (step * value) list -> t
-                  val list : t -> (step * value) list
-                  val empty : t
-                  val is_empty : t -> bool
-                  val find : t -> step -> value option
-                  val update : t -> step -> value -> t
-                  val remove : t -> step -> t
-                  val t : t Irmin.Type.ty
-                  val metadata_t : metadata Irmin.Type.ty
-                  val contents_t : node Irmin.Type.ty
-                  val node_t : node Irmin.Type.ty
-                  val step_t : step Irmin.Type.ty
-                  val value_t : value Irmin.Type.ty
-                end
-              module Contents :
-                sig
-                  type t =
-                      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Node.Contents.t
-                  type key = Val.node
-                  type value =
-                      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Node.Contents.value
-                  val mem : t -> key -> bool Lwt.t
-                  val find : t -> key -> value option Lwt.t
-                  val add : t -> value -> key Lwt.t
-                  val merge : t -> key option Irmin.Merge.t
-                  module Key :
-                    sig
-                      type t = key
-                      val digest : branch -> t
-                      val hash : t -> int
-                      val digest_size : int
-                      val t : t Irmin.Type.ty
-                    end
-                  module Val :
-                    sig
-                      type t = value
-                      val t : t Irmin.Type.ty
-                      val merge : t option Irmin.Merge.t
-                    end
-                end
-            end
-          module Commit :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.t
-              type key = Node.key
-              type value =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.value
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              val merge : t -> info:Irmin.Info.f -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : branch -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Val :
-                sig
-                  type t = value
-                  type commit = key
-                  type node = commit
-                  val v :
-                    info:Irmin.Info.t -> node:node -> parents:node list -> t
-                  val node : t -> node
-                  val parents : t -> node list
-                  val info : t -> Irmin.Info.t
-                  val t : t Irmin.Type.ty
-                  val commit_t : node Irmin.Type.ty
-                  val node_t : node Irmin.Type.ty
-                end
-              module Node :
-                sig
-                  type t =
-                      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.t
-                  type key = Val.node
-                  type value =
-                      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.value
-                  val mem : t -> key -> bool Lwt.t
-                  val find : t -> key -> value option Lwt.t
-                  val add : t -> value -> key Lwt.t
-                  module Path :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Path.t
-                      type step =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Path.step
-                      val empty : t
-                      val v : step list -> t
-                      val is_empty : t -> bool
-                      val cons : step -> t -> t
-                      val rcons : t -> step -> t
-                      val decons : t -> (step * t) option
-                      val rdecons : t -> (t * step) option
-                      val map : t -> (step -> 'a) -> 'a list
-                      val t : t Irmin.Type.ty
-                      val step_t : step Irmin.Type.ty
-                    end
-                  val merge : t -> key option Irmin.Merge.t
-                  module Key :
-                    sig
-                      type t = key
-                      val digest : branch -> t
-                      val hash : t -> int
-                      val digest_size : int
-                      val t : t Irmin.Type.ty
-                    end
-                  module Metadata :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Metadata.t
-                      val t : t Irmin.Type.ty
-                      val merge : t Irmin.Merge.t
-                      val default : t
-                    end
-                  module Val :
-                    sig
-                      type t = value
-                      type metadata = Metadata.t
-                      type contents =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Val.contents
-                      type node = key
-                      type step = Path.step
-                      type value =
-                          [ `Contents of contents * metadata | `Node of node ]
-                      val v : (step * value) list -> t
-                      val list : t -> (step * value) list
-                      val empty : t
-                      val is_empty : t -> bool
-                      val find : t -> step -> value option
-                      val update : t -> step -> value -> t
-                      val remove : t -> step -> t
-                      val t : t Irmin.Type.ty
-                      val metadata_t : metadata Irmin.Type.ty
-                      val contents_t : contents Irmin.Type.ty
-                      val node_t : node Irmin.Type.ty
-                      val step_t : step Irmin.Type.ty
-                      val value_t : value Irmin.Type.ty
-                    end
-                  module Contents :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Contents.t
-                      type key = Val.contents
-                      type value =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Contents.value
-                      val mem : t -> key -> bool Lwt.t
-                      val find : t -> key -> value option Lwt.t
-                      val add : t -> value -> key Lwt.t
-                      val merge : t -> key option Irmin.Merge.t
-                      module Key :
-                        sig
-                          type t = key
-                          val digest : branch -> t
-                          val hash : t -> int
-                          val digest_size : int
-                          val t : t Irmin.Type.ty
-                        end
-                      module Val :
-                        sig
-                          type t = value
-                          val t : t Irmin.Type.ty
-                          val merge : t option Irmin.Merge.t
-                        end
-                    end
-                end
-            end
-          module Branch :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Branch.t
-              type key = branch
-              type value = Commit.key
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val set : t -> key -> value -> metadata Lwt.t
-              val test_and_set :
-                t ->
-                key -> test:value option -> set:value option -> bool Lwt.t
-              val remove : t -> key -> metadata Lwt.t
-              type watch =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Branch.watch
-              val watch :
-                t ->
-                ?init:(key * value) list ->
-                (key -> value Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-              val watch_key :
-                t ->
-                key ->
-                ?init:value ->
-                (value Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-              val unwatch : t -> watch -> metadata Lwt.t
-              val list : t -> key list Lwt.t
-              module Key :
-                sig
-                  type t = key
-                  val t : t Irmin.Type.ty
-                  val master : t
-                  val is_valid : t -> bool
-                end
-              module Val :
-                sig
-                  type t = value
-                  val digest : key -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-            end
-          module Slice :
-            sig
-              type t = slice
-              type contents = Branch.value * Contents.value
-              type node = Branch.value * Node.value
-              type commit = Branch.value * Commit.value
-              type value =
-                  [ `Commit of commit | `Contents of contents | `Node of node ]
-              val empty : metadata -> t Lwt.t
-              val add : t -> value -> metadata Lwt.t
-              val iter : t -> (value -> metadata Lwt.t) -> metadata Lwt.t
-              val t : t Irmin.Type.ty
-              val contents_t : contents Irmin.Type.ty
-              val node_t : node Irmin.Type.ty
-              val commit_t : commit Irmin.Type.ty
-              val value_t : value Irmin.Type.ty
-            end
-          module Repo :
-            sig
-              type t = repo
-              val v : Irmin.config -> t Lwt.t
-              val contents_t : t -> Contents.t
-              val node_t : t -> Node.t
-              val commit_t : t -> Commit.t
-              val branch_t : t -> Branch.t
-            end
-          module Sync :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Sync.t
-              type commit = Branch.value
-              type branch = step
-              type endpoint =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Sync.endpoint
-              val fetch :
-                t ->
-                ?depth:int ->
-                endpoint ->
-                branch ->
-                (commit, [ `Msg of branch | `No_head | `Not_available ])
-                result Lwt.t
-              val push :
-                t ->
-                ?depth:int ->
-                endpoint ->
-                branch ->
-                (metadata,
-                 [ `Detached_head
-                 | `Msg of branch
-                 | `No_head
-                 | `Not_available ])
-                result Lwt.t
-              val v : repo -> t Lwt.t
-            end
+
+        module Val : sig
+          type t = value
+
+          type metadata = Metadata.t
+
+          type contents =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Val.contents
+
+          type node = key
+
+          type step = Path.step
+
+          type value =
+            [ `Contents of contents * metadata
+            | `Node of node ]
+
+          val v : (step * value) list -> t
+
+          val list : t -> (step * value) list
+
+          val empty : t
+
+          val is_empty : t -> bool
+
+          val find : t -> step -> value option
+
+          val update : t -> step -> value -> t
+
+          val remove : t -> step -> t
+
+          val t : t Irmin.Type.ty
+
+          val metadata_t : metadata Irmin.Type.ty
+
+          val contents_t : contents Irmin.Type.ty
+
+          val node_t : node Irmin.Type.ty
+
+          val step_t : step Irmin.Type.ty
+
+          val value_t : value Irmin.Type.ty
         end
-      type Irmin.remote += E of Private.Sync.endpoint
-      val flush : DB.t -> int64 Lwt.t
+
+        module Contents : sig
+          type t =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Contents.t
+
+          type key = Val.contents
+
+          type value =
+            Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Commit.Node.Contents
+            .value
+
+          val mem : t -> key -> bool Lwt.t
+
+          val find : t -> key -> value option Lwt.t
+
+          val add : t -> value -> key Lwt.t
+
+          val merge : t -> key option Irmin.Merge.t
+
+          module Key : sig
+            type t = key
+
+            val digest : string -> t
+
+            val hash : t -> int
+
+            val digest_size : int
+
+            val t : t Irmin.Type.ty
+          end
+
+          module Val : sig
+            type t = value
+
+            val t : t Irmin.Type.ty
+
+            val merge : t option Irmin.Merge.t
+          end
+        end
+      end
     end
-module KV_git :
-  functor (DB : DB) ->
-    sig
-      module DB :
-        sig
-          module Stor : Wodan.S
-          type t = DB.t
-          val db_root : t -> Stor.root
-          val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-          val v : Irmin.config -> t Lwt.t
-          val flush : t -> int64 Lwt.t
+
+    module Branch : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Branch.t
+
+      type key = branch
+
+      type value = Commit.key
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val set : t -> key -> value -> unit Lwt.t
+
+      val test_and_set :
+        t -> key -> test:value option -> set:value option -> bool Lwt.t
+
+      val remove : t -> key -> unit Lwt.t
+
+      type watch = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Branch.watch
+
+      val watch :
+        t ->
+        ?init:(key * value) list ->
+        (key -> value Irmin.diff -> unit Lwt.t) ->
+        watch Lwt.t
+
+      val watch_key :
+        t ->
+        key ->
+        ?init:value ->
+        (value Irmin.diff -> unit Lwt.t) ->
+        watch Lwt.t
+
+      val unwatch : t -> watch -> unit Lwt.t
+
+      val list : t -> key list Lwt.t
+
+      module Key : sig
+        type t = key
+
+        val t : t Irmin.Type.ty
+
+        val master : t
+
+        val is_valid : t -> bool
+      end
+
+      module Val : sig
+        type t = value
+
+        val digest : string -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+    end
+
+    module Slice : sig
+      type t = slice
+
+      type contents = Branch.value * Contents.value
+
+      type node = Branch.value * Node.value
+
+      type commit = Branch.value * Commit.value
+
+      type value =
+        [ `Commit of commit
+        | `Contents of contents
+        | `Node of node ]
+
+      val empty : unit -> t Lwt.t
+
+      val add : t -> value -> unit Lwt.t
+
+      val iter : t -> (value -> unit Lwt.t) -> unit Lwt.t
+
+      val t : t Irmin.Type.ty
+
+      val contents_t : contents Irmin.Type.ty
+
+      val node_t : node Irmin.Type.ty
+
+      val commit_t : commit Irmin.Type.ty
+
+      val value_t : value Irmin.Type.ty
+    end
+
+    module Repo : sig
+      type t = repo
+
+      val v : Irmin.config -> t Lwt.t
+
+      val contents_t : t -> Contents.t
+
+      val node_t : t -> Node.t
+
+      val commit_t : t -> Commit.t
+
+      val branch_t : t -> Branch.t
+    end
+
+    module Sync : sig
+      type t = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Sync.t
+
+      type commit = Branch.value
+
+      type branch = Branch.key
+
+      type endpoint = Irmin.Make(AO)(RW)(M)(C)(P)(B)(H).Private.Sync.endpoint
+
+      val fetch :
+        t ->
+        ?depth:int ->
+        endpoint ->
+        branch ->
+        (commit, [`Msg of string | `No_head | `Not_available]) result Lwt.t
+
+      val push :
+        t ->
+        ?depth:int ->
+        endpoint ->
+        branch ->
+        ( unit,
+          [`Detached_head | `Msg of string | `No_head | `Not_available] )
+        result
+        Lwt.t
+
+      val v : repo -> t Lwt.t
+    end
+  end
+
+  type Irmin.remote += E of Private.Sync.endpoint
+
+  val flush : DB.t -> int64 Lwt.t
+end
+
+module KV (DB : DB) (C : Irmin.Contents.S) : sig
+  module DB : sig
+    module Stor : Wodan.S
+
+    type t = DB.t
+
+    val db_root : t -> Stor.root
+
+    val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+
+    val flush : t -> int64 Lwt.t
+  end
+
+  module AO (K : Irmin.Hash.S) (V : Irmin.Type.S) : sig
+    type t = AO_BUILDER(DB)(K)(V).t
+
+    type key = K.t
+
+    type value = V.t
+
+    val mem : t -> key -> bool Lwt.t
+
+    val find : t -> key -> value option Lwt.t
+
+    val add : t -> value -> key Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+  end
+
+  module RW (K : Irmin.Type.S) (V : Irmin.Type.S) : sig
+    type t = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).t
+
+    type key = K.t
+
+    type value = V.t
+
+    val mem : t -> key -> bool Lwt.t
+
+    val find : t -> key -> value option Lwt.t
+
+    val set : t -> key -> value -> unit Lwt.t
+
+    val test_and_set :
+      t -> key -> test:value option -> set:value option -> bool Lwt.t
+
+    val remove : t -> key -> unit Lwt.t
+
+    val list : t -> key list Lwt.t
+
+    type watch = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).watch
+
+    val watch :
+      t ->
+      ?init:(key * value) list ->
+      (key -> value Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val watch_key :
+      t ->
+      key ->
+      ?init:value ->
+      (value Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val unwatch : t -> watch -> unit Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+  end
+
+  type repo =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .repo
+
+  type t =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .t
+
+  type step = string
+
+  type key = Irmin.Path.String_list.t
+
+  type metadata = unit
+
+  type contents = C.t
+
+  type node =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .node
+
+  type tree =
+    [ `Contents of contents * metadata
+    | `Node of node ]
+
+  type commit =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .commit
+
+  type branch = step
+
+  type slice =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .slice
+
+  type lca_error =
+    [ `Max_depth_reached
+    | `Too_many_lcas ]
+
+  type ff_error =
+    [ `Max_depth_reached
+    | `No_change
+    | `Rejected
+    | `Too_many_lcas ]
+
+  module Repo : sig
+    type t = repo
+
+    val v : Irmin.config -> t Lwt.t
+
+    val heads : t -> commit list Lwt.t
+
+    val branches : t -> branch list Lwt.t
+
+    val export :
+      ?full:bool ->
+      ?depth:int ->
+      ?min:commit list ->
+      ?max:commit list ->
+      t ->
+      slice Lwt.t
+
+    val import : t -> slice -> (metadata, [`Msg of branch]) result Lwt.t
+  end
+
+  val empty : repo -> t Lwt.t
+
+  val master : repo -> t Lwt.t
+
+  val of_branch : repo -> branch -> t Lwt.t
+
+  val of_commit : commit -> t Lwt.t
+
+  val repo : t -> repo
+
+  val tree : t -> tree Lwt.t
+
+  module Status : sig
+    type t =
+      [ `Branch of branch
+      | `Commit of commit
+      | `Empty ]
+
+    val t : repo -> t Irmin.Type.ty
+
+    val pp : t Fmt.t
+  end
+
+  val status : t -> Status.t
+
+  module Head : sig
+    val list : repo -> commit list Lwt.t
+
+    val find : t -> commit option Lwt.t
+
+    val get : t -> commit Lwt.t
+
+    val set : t -> commit -> metadata Lwt.t
+
+    val fast_forward :
+      t ->
+      ?max_depth:int ->
+      ?n:int ->
+      commit ->
+      ( metadata,
+        [`Max_depth_reached | `No_change | `Rejected | `Too_many_lcas] )
+      result
+      Lwt.t
+
+    val test_and_set :
+      t -> test:commit option -> set:commit option -> bool Lwt.t
+
+    val merge :
+      into:t ->
+      info:Irmin.Info.f ->
+      ?max_depth:int ->
+      ?n:int ->
+      commit ->
+      (metadata, Irmin.Merge.conflict) result Lwt.t
+  end
+
+  module Commit : sig
+    type t = commit
+
+    val t : repo -> t Irmin.Type.ty
+
+    val pp_hash : t Fmt.t
+
+    val v : repo -> info:Irmin.Info.t -> parents:t list -> tree -> t Lwt.t
+
+    val tree : t -> tree Lwt.t
+
+    val parents : t -> t list Lwt.t
+
+    val info : t -> Irmin.Info.t
+
+    module Hash : sig
+      type t = Irmin.Hash.SHA1.t
+
+      val digest : branch -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash = Hash.t
+
+    val hash : t -> hash
+
+    val of_hash : repo -> hash -> t option Lwt.t
+  end
+
+  module Contents : sig
+    type t = contents
+
+    val t : t Irmin.Type.ty
+
+    val merge : t option Irmin.Merge.t
+
+    module Hash : sig
+      type t = Commit.hash
+
+      val digest : branch -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash = Hash.t
+
+    val hash : repo -> t -> hash Lwt.t
+
+    val of_hash : repo -> hash -> t option Lwt.t
+  end
+
+  module Tree : sig
+    val empty : tree
+
+    val of_contents : ?metadata:metadata -> contents -> tree
+
+    val of_node : node -> tree
+
+    val kind : tree -> key -> [`Contents | `Node] option Lwt.t
+
+    val list : tree -> key -> (branch * [`Contents | `Node]) list Lwt.t
+
+    val diff :
+      tree -> tree -> (key * (contents * metadata) Irmin.diff) list Lwt.t
+
+    val mem : tree -> key -> bool Lwt.t
+
+    val find_all : tree -> key -> (contents * metadata) option Lwt.t
+
+    val find : tree -> key -> contents option Lwt.t
+
+    val get_all : tree -> key -> (contents * metadata) Lwt.t
+
+    val get : tree -> key -> contents Lwt.t
+
+    val add : tree -> key -> ?metadata:metadata -> contents -> tree Lwt.t
+
+    val remove : tree -> key -> tree Lwt.t
+
+    val mem_tree : tree -> key -> bool Lwt.t
+
+    val find_tree : tree -> key -> tree option Lwt.t
+
+    val get_tree : tree -> key -> tree Lwt.t
+
+    val add_tree : tree -> key -> tree -> tree Lwt.t
+
+    val merge : tree Irmin.Merge.t
+
+    val clear_caches : tree -> metadata
+
+    type marks =
+      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+        (Irmin.Branch.String)
+        (Irmin.Hash.SHA1)
+      .Tree
+      .marks
+
+    val empty_marks : metadata -> marks
+
+    type 'a force =
+      [ `False of key -> 'a -> 'a Lwt.t
+      | `True ]
+
+    type uniq =
+      [ `False
+      | `Marks of marks
+      | `True ]
+
+    type 'a node_fn = key -> branch list -> 'a -> 'a Lwt.t
+
+    val fold :
+      ?force:'a force ->
+      ?uniq:uniq ->
+      ?pre:'a node_fn ->
+      ?post:'a node_fn ->
+      (key -> contents -> 'a -> 'a Lwt.t) ->
+      tree ->
+      'a ->
+      'a Lwt.t
+
+    type stats =
+                Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)
+                  (Irmin.Path.String_list)
+                  (Irmin.Branch.String)
+                  (Irmin.Hash.SHA1)
+                .Tree
+                .stats = {
+      nodes : int;
+      leafs : int;
+      skips : int;
+      depth : int;
+      width : int
+    }
+
+    val pp_stats : stats Fmt.t
+
+    val stats : ?force:bool -> tree -> stats Lwt.t
+
+    type concrete =
+      [ `Contents of contents * metadata
+      | `Tree of (branch * concrete) list ]
+
+    val of_concrete : concrete -> tree
+
+    val to_concrete : tree -> concrete Lwt.t
+
+    module Hash : sig
+      type t = Contents.hash
+
+      val digest : branch -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash =
+      [ `Contents of Hash.t * metadata
+      | `Node of Hash.t ]
+
+    val hash_t : hash Irmin.Type.ty
+
+    val hash : repo -> tree -> hash Lwt.t
+
+    val of_hash : repo -> hash -> tree option Lwt.t
+  end
+
+  val kind : t -> key -> [`Contents | `Node] option Lwt.t
+
+  val list : t -> key -> (branch * [`Contents | `Node]) list Lwt.t
+
+  val mem : t -> key -> bool Lwt.t
+
+  val mem_tree : t -> key -> bool Lwt.t
+
+  val find_all : t -> key -> (contents * metadata) option Lwt.t
+
+  val find : t -> key -> contents option Lwt.t
+
+  val get_all : t -> key -> (contents * metadata) Lwt.t
+
+  val get : t -> key -> contents Lwt.t
+
+  val find_tree : t -> key -> tree option Lwt.t
+
+  val get_tree : t -> key -> tree Lwt.t
+
+  type 'a transaction =
+    ?retries:int ->
+    ?allow_empty:bool ->
+    ?strategy:[`Merge_with_parent of commit | `Set | `Test_and_set] ->
+    info:Irmin.Info.f ->
+    'a ->
+    metadata Lwt.t
+
+  val with_tree : t -> key -> (tree option -> tree option Lwt.t) transaction
+
+  val set : t -> key -> ?metadata:metadata -> contents transaction
+
+  val set_tree : t -> key -> tree transaction
+
+  val remove : t -> key transaction
+
+  val clone : src:t -> dst:branch -> t Lwt.t
+
+  type watch =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .watch
+
+  val watch :
+    t -> ?init:commit -> (commit Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
+
+  val watch_key :
+    t ->
+    key ->
+    ?init:commit ->
+    ((commit * tree) Irmin.diff -> metadata Lwt.t) ->
+    watch Lwt.t
+
+  val unwatch : watch -> metadata Lwt.t
+
+  type 'a merge =
+    info:Irmin.Info.f ->
+    ?max_depth:int ->
+    ?n:int ->
+    'a ->
+    (metadata, Irmin.Merge.conflict) result Lwt.t
+
+  val merge : into:t -> t merge
+
+  val merge_with_branch : t -> branch merge
+
+  val merge_with_commit : t -> commit merge
+
+  val lcas :
+    ?max_depth:int ->
+    ?n:int ->
+    t ->
+    t ->
+    (commit list, lca_error) result Lwt.t
+
+  val lcas_with_branch :
+    t ->
+    ?max_depth:int ->
+    ?n:int ->
+    branch ->
+    (commit list, lca_error) result Lwt.t
+
+  val lcas_with_commit :
+    t ->
+    ?max_depth:int ->
+    ?n:int ->
+    commit ->
+    (commit list, lca_error) result Lwt.t
+
+  module History : sig
+    type t =
+      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+        (Irmin.Branch.String)
+        (Irmin.Hash.SHA1)
+      .History
+      .t
+
+    module V : sig
+      type t = commit
+
+      val compare : t -> t -> int
+
+      val hash : t -> int
+
+      val equal : t -> t -> bool
+
+      type label =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .History
+        .V
+        .label
+
+      val create : label -> t
+
+      val label : t -> label
+    end
+
+    type vertex = commit
+
+    module E : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .History
+        .E
+        .t
+
+      val compare : t -> t -> int
+
+      type vertex = commit
+
+      val src : t -> vertex
+
+      val dst : t -> vertex
+
+      type label =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .History
+        .E
+        .label
+
+      val create : vertex -> label -> vertex -> t
+
+      val label : t -> label
+    end
+
+    type edge = E.t
+
+    val is_directed : bool
+
+    val is_empty : t -> bool
+
+    val nb_vertex : t -> int
+
+    val nb_edges : t -> int
+
+    val out_degree : t -> vertex -> int
+
+    val in_degree : t -> vertex -> int
+
+    val mem_vertex : t -> vertex -> bool
+
+    val mem_edge : t -> vertex -> vertex -> bool
+
+    val mem_edge_e : t -> edge -> bool
+
+    val find_edge : t -> vertex -> vertex -> edge
+
+    val find_all_edges : t -> vertex -> vertex -> edge list
+
+    val succ : t -> vertex -> vertex list
+
+    val pred : t -> vertex -> vertex list
+
+    val succ_e : t -> vertex -> edge list
+
+    val pred_e : t -> vertex -> edge list
+
+    val iter_vertex : (vertex -> metadata) -> t -> metadata
+
+    val fold_vertex : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val iter_edges : (vertex -> vertex -> metadata) -> t -> metadata
+
+    val fold_edges : (vertex -> vertex -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val iter_edges_e : (edge -> metadata) -> t -> metadata
+
+    val fold_edges_e : (edge -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val map_vertex : (vertex -> vertex) -> t -> t
+
+    val iter_succ : (vertex -> metadata) -> t -> vertex -> metadata
+
+    val iter_pred : (vertex -> metadata) -> t -> vertex -> metadata
+
+    val fold_succ : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val fold_pred : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val iter_succ_e : (edge -> metadata) -> t -> vertex -> metadata
+
+    val fold_succ_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val iter_pred_e : (edge -> metadata) -> t -> vertex -> metadata
+
+    val fold_pred_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val empty : t
+
+    val add_vertex : t -> vertex -> t
+
+    val remove_vertex : t -> vertex -> t
+
+    val add_edge : t -> vertex -> vertex -> t
+
+    val add_edge_e : t -> edge -> t
+
+    val remove_edge : t -> vertex -> vertex -> t
+
+    val remove_edge_e : t -> edge -> t
+  end
+
+  val history :
+    ?depth:int -> ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
+
+  module Branch : sig
+    val mem : repo -> branch -> bool Lwt.t
+
+    val find : repo -> branch -> commit option Lwt.t
+
+    val get : repo -> branch -> commit Lwt.t
+
+    val set : repo -> branch -> commit -> metadata Lwt.t
+
+    val remove : repo -> branch -> metadata Lwt.t
+
+    val list : repo -> branch list Lwt.t
+
+    val watch :
+      repo ->
+      branch ->
+      ?init:commit ->
+      (commit Irmin.diff -> metadata Lwt.t) ->
+      watch Lwt.t
+
+    val watch_all :
+      repo ->
+      ?init:(branch * commit) list ->
+      (branch -> commit Irmin.diff -> metadata Lwt.t) ->
+      watch Lwt.t
+
+    type t = branch
+
+    val t : t Irmin.Type.ty
+
+    val master : t
+
+    val is_valid : t -> bool
+  end
+
+  module Key : sig
+    type t = key
+
+    type step = branch
+
+    val empty : t
+
+    val v : step list -> t
+
+    val is_empty : t -> bool
+
+    val cons : step -> t -> t
+
+    val rcons : t -> step -> t
+
+    val decons : t -> (step * t) option
+
+    val rdecons : t -> (t * step) option
+
+    val map : t -> (step -> 'a) -> 'a list
+
+    val t : t Irmin.Type.ty
+
+    val step_t : step Irmin.Type.ty
+  end
+
+  module Metadata : sig
+    type t = metadata
+
+    val t : t Irmin.Type.ty
+
+    val merge : t Irmin.Merge.t
+
+    val default : t
+  end
+
+  val step_t : branch Irmin.Type.ty
+
+  val key_t : key Irmin.Type.ty
+
+  val metadata_t : metadata Irmin.Type.ty
+
+  val contents_t : contents Irmin.Type.ty
+
+  val node_t : node Irmin.Type.ty
+
+  val tree_t : tree Irmin.Type.ty
+
+  val commit_t : repo -> commit Irmin.Type.ty
+
+  val branch_t : branch Irmin.Type.ty
+
+  val slice_t : slice Irmin.Type.ty
+
+  val kind_t : [`Contents | `Node] Irmin.Type.ty
+
+  val lca_error_t : lca_error Irmin.Type.ty
+
+  val ff_error_t : ff_error Irmin.Type.ty
+
+  module Private : sig
+    module Contents : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Contents
+        .t
+
+      type key = Contents.hash
+
+      type value = contents
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      val merge : t -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : branch -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Val : sig
+        type t = value
+
+        val t : t Irmin.Type.ty
+
+        val merge : t option Irmin.Merge.t
+      end
+    end
+
+    module Node : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Node
+        .t
+
+      type key = Contents.key
+
+      type value =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Node
+        .value
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      module Path : sig
+        type t = Key.t
+
+        type step = branch
+
+        val empty : t
+
+        val v : step list -> t
+
+        val is_empty : t -> bool
+
+        val cons : step -> t -> t
+
+        val rcons : t -> step -> t
+
+        val decons : t -> (step * t) option
+
+        val rdecons : t -> (t * step) option
+
+        val map : t -> (step -> 'a) -> 'a list
+
+        val t : t Irmin.Type.ty
+
+        val step_t : step Irmin.Type.ty
+      end
+
+      val merge : t -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : branch -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Metadata : sig
+        type t = metadata
+
+        val t : t Irmin.Type.ty
+
+        val merge : t Irmin.Merge.t
+
+        val default : t
+      end
+
+      module Val : sig
+        type t = value
+
+        type metadata = unit
+
+        type contents = key
+
+        type node = contents
+
+        type step = branch
+
+        type value =
+          [ `Contents of node * metadata
+          | `Node of node ]
+
+        val v : (step * value) list -> t
+
+        val list : t -> (step * value) list
+
+        val empty : t
+
+        val is_empty : t -> bool
+
+        val find : t -> step -> value option
+
+        val update : t -> step -> value -> t
+
+        val remove : t -> step -> t
+
+        val t : t Irmin.Type.ty
+
+        val metadata_t : metadata Irmin.Type.ty
+
+        val contents_t : node Irmin.Type.ty
+
+        val node_t : node Irmin.Type.ty
+
+        val step_t : step Irmin.Type.ty
+
+        val value_t : value Irmin.Type.ty
+      end
+
+      module Contents : sig
+        type t =
+          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+            (Irmin.Branch.String)
+            (Irmin.Hash.SHA1)
+          .Private
+          .Node
+          .Contents
+          .t
+
+        type key = Val.node
+
+        type value =
+          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+            (Irmin.Branch.String)
+            (Irmin.Hash.SHA1)
+          .Private
+          .Node
+          .Contents
+          .value
+
+        val mem : t -> key -> bool Lwt.t
+
+        val find : t -> key -> value option Lwt.t
+
+        val add : t -> value -> key Lwt.t
+
+        val merge : t -> key option Irmin.Merge.t
+
+        module Key : sig
+          type t = key
+
+          val digest : branch -> t
+
+          val hash : t -> int
+
+          val digest_size : int
+
+          val t : t Irmin.Type.ty
         end
-      module AO :
-        functor (K : Irmin.Hash.S) (V : Irmin.Type.S) ->
-          sig
-            type t =
-                Irmin_chunk.AO_stable(LINK_BUILDER(DB))(AO_BUILDER(DB))(K)(V).t
-            type key = K.t
-            type value = V.t
-            val mem : t -> key -> bool Lwt.t
-            val find : t -> key -> value option Lwt.t
-            val add : t -> value -> key Lwt.t
-            val v : Irmin.config -> t Lwt.t
+
+        module Val : sig
+          type t = value
+
+          val t : t Irmin.Type.ty
+
+          val merge : t option Irmin.Merge.t
+        end
+      end
+    end
+
+    module Commit : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Commit
+        .t
+
+      type key = Node.key
+
+      type value =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Commit
+        .value
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      val merge : t -> info:Irmin.Info.f -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : branch -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Val : sig
+        type t = value
+
+        type commit = key
+
+        type node = commit
+
+        val v : info:Irmin.Info.t -> node:node -> parents:node list -> t
+
+        val node : t -> node
+
+        val parents : t -> node list
+
+        val info : t -> Irmin.Info.t
+
+        val t : t Irmin.Type.ty
+
+        val commit_t : node Irmin.Type.ty
+
+        val node_t : node Irmin.Type.ty
+      end
+
+      module Node : sig
+        type t =
+          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+            (Irmin.Branch.String)
+            (Irmin.Hash.SHA1)
+          .Private
+          .Commit
+          .Node
+          .t
+
+        type key = Val.node
+
+        type value =
+          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+            (Irmin.Branch.String)
+            (Irmin.Hash.SHA1)
+          .Private
+          .Commit
+          .Node
+          .value
+
+        val mem : t -> key -> bool Lwt.t
+
+        val find : t -> key -> value option Lwt.t
+
+        val add : t -> value -> key Lwt.t
+
+        module Path : sig
+          type t =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Path
+            .t
+
+          type step =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Path
+            .step
+
+          val empty : t
+
+          val v : step list -> t
+
+          val is_empty : t -> bool
+
+          val cons : step -> t -> t
+
+          val rcons : t -> step -> t
+
+          val decons : t -> (step * t) option
+
+          val rdecons : t -> (t * step) option
+
+          val map : t -> (step -> 'a) -> 'a list
+
+          val t : t Irmin.Type.ty
+
+          val step_t : step Irmin.Type.ty
+        end
+
+        val merge : t -> key option Irmin.Merge.t
+
+        module Key : sig
+          type t = key
+
+          val digest : branch -> t
+
+          val hash : t -> int
+
+          val digest_size : int
+
+          val t : t Irmin.Type.ty
+        end
+
+        module Metadata : sig
+          type t =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Metadata
+            .t
+
+          val t : t Irmin.Type.ty
+
+          val merge : t Irmin.Merge.t
+
+          val default : t
+        end
+
+        module Val : sig
+          type t = value
+
+          type metadata = Metadata.t
+
+          type contents =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Val
+            .contents
+
+          type node = key
+
+          type step = Path.step
+
+          type value =
+            [ `Contents of contents * metadata
+            | `Node of node ]
+
+          val v : (step * value) list -> t
+
+          val list : t -> (step * value) list
+
+          val empty : t
+
+          val is_empty : t -> bool
+
+          val find : t -> step -> value option
+
+          val update : t -> step -> value -> t
+
+          val remove : t -> step -> t
+
+          val t : t Irmin.Type.ty
+
+          val metadata_t : metadata Irmin.Type.ty
+
+          val contents_t : contents Irmin.Type.ty
+
+          val node_t : node Irmin.Type.ty
+
+          val step_t : step Irmin.Type.ty
+
+          val value_t : value Irmin.Type.ty
+        end
+
+        module Contents : sig
+          type t =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Contents
+            .t
+
+          type key = Val.contents
+
+          type value =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Contents
+            .value
+
+          val mem : t -> key -> bool Lwt.t
+
+          val find : t -> key -> value option Lwt.t
+
+          val add : t -> value -> key Lwt.t
+
+          val merge : t -> key option Irmin.Merge.t
+
+          module Key : sig
+            type t = key
+
+            val digest : branch -> t
+
+            val hash : t -> int
+
+            val digest_size : int
+
+            val t : t Irmin.Type.ty
           end
-      module RW :
-        functor (K : Irmin.Type.S) (V : Irmin.Type.S) ->
-          sig
-            type t = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).t
-            type key = K.t
-            type value = V.t
-            val mem : t -> key -> bool Lwt.t
-            val find : t -> key -> value option Lwt.t
-            val set : t -> key -> value -> unit Lwt.t
-            val test_and_set :
-              t -> key -> test:value option -> set:value option -> bool Lwt.t
-            val remove : t -> key -> unit Lwt.t
-            val list : t -> key list Lwt.t
-            type watch = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).watch
-            val watch :
-              t ->
-              ?init:(key * value) list ->
-              (key -> value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-            val watch_key :
-              t ->
-              key ->
-              ?init:value -> (value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-            val unwatch : t -> watch -> unit Lwt.t
-            val v : Irmin.config -> t Lwt.t
+
+          module Val : sig
+            type t = value
+
+            val t : t Irmin.Type.ty
+
+            val merge : t option Irmin.Merge.t
           end
-      type repo = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).repo
-      type t = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).t
-      type step = string
-      type key = step list
-      type metadata =
-          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).metadata
-      type contents = step
-      type node = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).node
-      type tree = [ `Contents of contents * metadata | `Node of node ]
-      type commit =
-          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).commit
+        end
+      end
+    end
+
+    module Branch : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Branch
+        .t
+
+      type key = branch
+
+      type value = Commit.key
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val set : t -> key -> value -> metadata Lwt.t
+
+      val test_and_set :
+        t -> key -> test:value option -> set:value option -> bool Lwt.t
+
+      val remove : t -> key -> metadata Lwt.t
+
+      type watch =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Branch
+        .watch
+
+      val watch :
+        t ->
+        ?init:(key * value) list ->
+        (key -> value Irmin.diff -> metadata Lwt.t) ->
+        watch Lwt.t
+
+      val watch_key :
+        t ->
+        key ->
+        ?init:value ->
+        (value Irmin.diff -> metadata Lwt.t) ->
+        watch Lwt.t
+
+      val unwatch : t -> watch -> metadata Lwt.t
+
+      val list : t -> key list Lwt.t
+
+      module Key : sig
+        type t = key
+
+        val t : t Irmin.Type.ty
+
+        val master : t
+
+        val is_valid : t -> bool
+      end
+
+      module Val : sig
+        type t = value
+
+        val digest : key -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+    end
+
+    module Slice : sig
+      type t = slice
+
+      type contents = Branch.value * Contents.value
+
+      type node = Branch.value * Node.value
+
+      type commit = Branch.value * Commit.value
+
+      type value =
+        [ `Commit of commit
+        | `Contents of contents
+        | `Node of node ]
+
+      val empty : metadata -> t Lwt.t
+
+      val add : t -> value -> metadata Lwt.t
+
+      val iter : t -> (value -> metadata Lwt.t) -> metadata Lwt.t
+
+      val t : t Irmin.Type.ty
+
+      val contents_t : contents Irmin.Type.ty
+
+      val node_t : node Irmin.Type.ty
+
+      val commit_t : commit Irmin.Type.ty
+
+      val value_t : value Irmin.Type.ty
+    end
+
+    module Repo : sig
+      type t = repo
+
+      val v : Irmin.config -> t Lwt.t
+
+      val contents_t : t -> Contents.t
+
+      val node_t : t -> Node.t
+
+      val commit_t : t -> Commit.t
+
+      val branch_t : t -> Branch.t
+    end
+
+    module Sync : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Sync
+        .t
+
+      type commit = Branch.value
+
+      type branch = step
+
+      type endpoint =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Sync
+        .endpoint
+
+      val fetch :
+        t ->
+        ?depth:int ->
+        endpoint ->
+        branch ->
+        (commit, [`Msg of branch | `No_head | `Not_available]) result Lwt.t
+
+      val push :
+        t ->
+        ?depth:int ->
+        endpoint ->
+        branch ->
+        ( metadata,
+          [`Detached_head | `Msg of branch | `No_head | `Not_available] )
+        result
+        Lwt.t
+
+      val v : repo -> t Lwt.t
+    end
+  end
+
+  type Irmin.remote += E of Private.Sync.endpoint
+
+  val flush : DB.t -> int64 Lwt.t
+end
+
+module KV_git (DB : DB) : sig
+  module DB : sig
+    module Stor : Wodan.S
+
+    type t = DB.t
+
+    val db_root : t -> Stor.root
+
+    val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+
+    val flush : t -> int64 Lwt.t
+  end
+
+  module AO (K : Irmin.Hash.S) (V : Irmin.Type.S) : sig
+    type t = Irmin_chunk.AO_stable(LINK_BUILDER(DB))(AO_BUILDER(DB))(K)(V).t
+
+    type key = K.t
+
+    type value = V.t
+
+    val mem : t -> key -> bool Lwt.t
+
+    val find : t -> key -> value option Lwt.t
+
+    val add : t -> value -> key Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+  end
+
+  module RW (K : Irmin.Type.S) (V : Irmin.Type.S) : sig
+    type t = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).t
+
+    type key = K.t
+
+    type value = V.t
+
+    val mem : t -> key -> bool Lwt.t
+
+    val find : t -> key -> value option Lwt.t
+
+    val set : t -> key -> value -> unit Lwt.t
+
+    val test_and_set :
+      t -> key -> test:value option -> set:value option -> bool Lwt.t
+
+    val remove : t -> key -> unit Lwt.t
+
+    val list : t -> key list Lwt.t
+
+    type watch = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).watch
+
+    val watch :
+      t ->
+      ?init:(key * value) list ->
+      (key -> value Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val watch_key :
+      t ->
+      key ->
+      ?init:value ->
+      (value Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val unwatch : t -> watch -> unit Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+  end
+
+  type repo = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).repo
+
+  type t = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).t
+
+  type step = string
+
+  type key = step list
+
+  type metadata = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).metadata
+
+  type contents = step
+
+  type node = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).node
+
+  type tree =
+    [ `Contents of contents * metadata
+    | `Node of node ]
+
+  type commit = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).commit
+
+  type branch = contents
+
+  type slice = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).slice
+
+  type lca_error =
+    [ `Max_depth_reached
+    | `Too_many_lcas ]
+
+  type ff_error =
+    [ `Max_depth_reached
+    | `No_change
+    | `Rejected
+    | `Too_many_lcas ]
+
+  module Repo : sig
+    type t = repo
+
+    val v : Irmin.config -> t Lwt.t
+
+    val heads : t -> commit list Lwt.t
+
+    val branches : t -> branch list Lwt.t
+
+    val export :
+      ?full:bool ->
+      ?depth:int ->
+      ?min:commit list ->
+      ?max:commit list ->
+      t ->
+      slice Lwt.t
+
+    val import : t -> slice -> (unit, [`Msg of branch]) result Lwt.t
+  end
+
+  val empty : repo -> t Lwt.t
+
+  val master : repo -> t Lwt.t
+
+  val of_branch : repo -> branch -> t Lwt.t
+
+  val of_commit : commit -> t Lwt.t
+
+  val repo : t -> repo
+
+  val tree : t -> tree Lwt.t
+
+  module Status : sig
+    type t =
+      [ `Branch of branch
+      | `Commit of commit
+      | `Empty ]
+
+    val t : repo -> t Irmin.Type.ty
+
+    val pp : t Fmt.t
+  end
+
+  val status : t -> Status.t
+
+  module Head : sig
+    val list : repo -> commit list Lwt.t
+
+    val find : t -> commit option Lwt.t
+
+    val get : t -> commit Lwt.t
+
+    val set : t -> commit -> unit Lwt.t
+
+    val fast_forward :
+      t ->
+      ?max_depth:int ->
+      ?n:int ->
+      commit ->
+      ( unit,
+        [`Max_depth_reached | `No_change | `Rejected | `Too_many_lcas] )
+      result
+      Lwt.t
+
+    val test_and_set :
+      t -> test:commit option -> set:commit option -> bool Lwt.t
+
+    val merge :
+      into:t ->
+      info:Irmin.Info.f ->
+      ?max_depth:int ->
+      ?n:int ->
+      commit ->
+      (unit, Irmin.Merge.conflict) result Lwt.t
+  end
+
+  module Commit : sig
+    type t = commit
+
+    val t : repo -> t Irmin.Type.ty
+
+    val pp_hash : t Fmt.t
+
+    val v : repo -> info:Irmin.Info.t -> parents:t list -> tree -> t Lwt.t
+
+    val tree : t -> tree Lwt.t
+
+    val parents : t -> t list Lwt.t
+
+    val info : t -> Irmin.Info.t
+
+    module Hash : sig
+      type t =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Commit.Hash.t
+
+      val digest : branch -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash = Hash.t
+
+    val hash : t -> hash
+
+    val of_hash : repo -> hash -> t option Lwt.t
+  end
+
+  module Contents : sig
+    type t = branch
+
+    val t : t Irmin.Type.ty
+
+    val merge : t option Irmin.Merge.t
+
+    module Hash : sig
+      type t =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Contents.Hash.t
+
+      val digest : branch -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash = Hash.t
+
+    val hash : repo -> t -> hash Lwt.t
+
+    val of_hash : repo -> hash -> t option Lwt.t
+  end
+
+  module Tree : sig
+    val empty : tree
+
+    val of_contents : ?metadata:metadata -> branch -> tree
+
+    val of_node : node -> tree
+
+    val kind : tree -> key -> [`Contents | `Node] option Lwt.t
+
+    val list : tree -> key -> (branch * [`Contents | `Node]) list Lwt.t
+
+    val diff :
+      tree -> tree -> (key * (branch * metadata) Irmin.diff) list Lwt.t
+
+    val mem : tree -> key -> bool Lwt.t
+
+    val find_all : tree -> key -> (branch * metadata) option Lwt.t
+
+    val find : tree -> key -> branch option Lwt.t
+
+    val get_all : tree -> key -> (branch * metadata) Lwt.t
+
+    val get : tree -> key -> branch Lwt.t
+
+    val add : tree -> key -> ?metadata:metadata -> branch -> tree Lwt.t
+
+    val remove : tree -> key -> tree Lwt.t
+
+    val mem_tree : tree -> key -> bool Lwt.t
+
+    val find_tree : tree -> key -> tree option Lwt.t
+
+    val get_tree : tree -> key -> tree Lwt.t
+
+    val add_tree : tree -> key -> tree -> tree Lwt.t
+
+    val merge : tree Irmin.Merge.t
+
+    val clear_caches : tree -> unit
+
+    type marks =
+      Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Tree.marks
+
+    val empty_marks : unit -> marks
+
+    type 'a force =
+      [ `False of key -> 'a -> 'a Lwt.t
+      | `True ]
+
+    type uniq =
+      [ `False
+      | `Marks of marks
+      | `True ]
+
+    type 'a node_fn = key -> branch list -> 'a -> 'a Lwt.t
+
+    val fold :
+      ?force:'a force ->
+      ?uniq:uniq ->
+      ?pre:'a node_fn ->
+      ?post:'a node_fn ->
+      (key -> branch -> 'a -> 'a Lwt.t) ->
+      tree ->
+      'a ->
+      'a Lwt.t
+
+    type stats =
+                Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Tree.stats = {
+      nodes : int;
+      leafs : int;
+      skips : int;
+      depth : int;
+      width : int
+    }
+
+    val pp_stats : stats Fmt.t
+
+    val stats : ?force:bool -> tree -> stats Lwt.t
+
+    type concrete =
+      [ `Contents of branch * metadata
+      | `Tree of (branch * concrete) list ]
+
+    val of_concrete : concrete -> tree
+
+    val to_concrete : tree -> concrete Lwt.t
+
+    module Hash : sig
+      type t = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Tree.Hash.t
+
+      val digest : branch -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash =
+      [ `Contents of Contents.hash * metadata
+      | `Node of Hash.t ]
+
+    val hash_t : hash Irmin.Type.ty
+
+    val hash : repo -> tree -> hash Lwt.t
+
+    val of_hash : repo -> hash -> tree option Lwt.t
+  end
+
+  val kind : t -> key -> [`Contents | `Node] option Lwt.t
+
+  val list : t -> key -> (branch * [`Contents | `Node]) list Lwt.t
+
+  val mem : t -> key -> bool Lwt.t
+
+  val mem_tree : t -> key -> bool Lwt.t
+
+  val find_all : t -> key -> (branch * metadata) option Lwt.t
+
+  val find : t -> key -> branch option Lwt.t
+
+  val get_all : t -> key -> (branch * metadata) Lwt.t
+
+  val get : t -> key -> branch Lwt.t
+
+  val find_tree : t -> key -> tree option Lwt.t
+
+  val get_tree : t -> key -> tree Lwt.t
+
+  type 'a transaction =
+    ?retries:int ->
+    ?allow_empty:bool ->
+    ?strategy:[`Merge_with_parent of commit | `Set | `Test_and_set] ->
+    info:Irmin.Info.f ->
+    'a ->
+    unit Lwt.t
+
+  val with_tree : t -> key -> (tree option -> tree option Lwt.t) transaction
+
+  val set : t -> key -> ?metadata:metadata -> branch transaction
+
+  val set_tree : t -> key -> tree transaction
+
+  val remove : t -> key transaction
+
+  val clone : src:t -> dst:branch -> t Lwt.t
+
+  type watch = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).watch
+
+  val watch :
+    t -> ?init:commit -> (commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
+
+  val watch_key :
+    t ->
+    key ->
+    ?init:commit ->
+    ((commit * tree) Irmin.diff -> unit Lwt.t) ->
+    watch Lwt.t
+
+  val unwatch : watch -> unit Lwt.t
+
+  type 'a merge =
+    info:Irmin.Info.f ->
+    ?max_depth:int ->
+    ?n:int ->
+    'a ->
+    (unit, Irmin.Merge.conflict) result Lwt.t
+
+  val merge : into:t -> t merge
+
+  val merge_with_branch : t -> branch merge
+
+  val merge_with_commit : t -> commit merge
+
+  val lcas :
+    ?max_depth:int ->
+    ?n:int ->
+    t ->
+    t ->
+    (commit list, lca_error) result Lwt.t
+
+  val lcas_with_branch :
+    t ->
+    ?max_depth:int ->
+    ?n:int ->
+    branch ->
+    (commit list, lca_error) result Lwt.t
+
+  val lcas_with_commit :
+    t ->
+    ?max_depth:int ->
+    ?n:int ->
+    commit ->
+    (commit list, lca_error) result Lwt.t
+
+  module History : sig
+    type t = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).History.t
+
+    module V : sig
+      type t = commit
+
+      val compare : t -> t -> int
+
+      val hash : t -> int
+
+      val equal : t -> t -> bool
+
+      type label =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).History.V.label
+
+      val create : label -> t
+
+      val label : t -> label
+    end
+
+    type vertex = commit
+
+    module E : sig
+      type t = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).History.E.t
+
+      val compare : t -> t -> int
+
+      type vertex = commit
+
+      val src : t -> vertex
+
+      val dst : t -> vertex
+
+      type label =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).History.E.label
+
+      val create : vertex -> label -> vertex -> t
+
+      val label : t -> label
+    end
+
+    type edge = E.t
+
+    val is_directed : bool
+
+    val is_empty : t -> bool
+
+    val nb_vertex : t -> int
+
+    val nb_edges : t -> int
+
+    val out_degree : t -> vertex -> int
+
+    val in_degree : t -> vertex -> int
+
+    val mem_vertex : t -> vertex -> bool
+
+    val mem_edge : t -> vertex -> vertex -> bool
+
+    val mem_edge_e : t -> edge -> bool
+
+    val find_edge : t -> vertex -> vertex -> edge
+
+    val find_all_edges : t -> vertex -> vertex -> edge list
+
+    val succ : t -> vertex -> vertex list
+
+    val pred : t -> vertex -> vertex list
+
+    val succ_e : t -> vertex -> edge list
+
+    val pred_e : t -> vertex -> edge list
+
+    val iter_vertex : (vertex -> unit) -> t -> unit
+
+    val fold_vertex : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val iter_edges : (vertex -> vertex -> unit) -> t -> unit
+
+    val fold_edges : (vertex -> vertex -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val iter_edges_e : (edge -> unit) -> t -> unit
+
+    val fold_edges_e : (edge -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val map_vertex : (vertex -> vertex) -> t -> t
+
+    val iter_succ : (vertex -> unit) -> t -> vertex -> unit
+
+    val iter_pred : (vertex -> unit) -> t -> vertex -> unit
+
+    val fold_succ : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val fold_pred : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val iter_succ_e : (edge -> unit) -> t -> vertex -> unit
+
+    val fold_succ_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val iter_pred_e : (edge -> unit) -> t -> vertex -> unit
+
+    val fold_pred_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val empty : t
+
+    val add_vertex : t -> vertex -> t
+
+    val remove_vertex : t -> vertex -> t
+
+    val add_edge : t -> vertex -> vertex -> t
+
+    val add_edge_e : t -> edge -> t
+
+    val remove_edge : t -> vertex -> vertex -> t
+
+    val remove_edge_e : t -> edge -> t
+  end
+
+  val history :
+    ?depth:int -> ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
+
+  module Branch : sig
+    val mem : repo -> branch -> bool Lwt.t
+
+    val find : repo -> branch -> commit option Lwt.t
+
+    val get : repo -> branch -> commit Lwt.t
+
+    val set : repo -> branch -> commit -> unit Lwt.t
+
+    val remove : repo -> branch -> unit Lwt.t
+
+    val list : repo -> branch list Lwt.t
+
+    val watch :
+      repo ->
+      branch ->
+      ?init:commit ->
+      (commit Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val watch_all :
+      repo ->
+      ?init:(branch * commit) list ->
+      (branch -> commit Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    type t = branch
+
+    val t : t Irmin.Type.ty
+
+    val master : t
+
+    val is_valid : t -> bool
+  end
+
+  module Key : sig
+    type t = key
+
+    type step = branch
+
+    val empty : t
+
+    val v : step list -> t
+
+    val is_empty : t -> bool
+
+    val cons : step -> t -> t
+
+    val rcons : t -> step -> t
+
+    val decons : t -> (step * t) option
+
+    val rdecons : t -> (t * step) option
+
+    val map : t -> (step -> 'a) -> 'a list
+
+    val t : t Irmin.Type.ty
+
+    val step_t : step Irmin.Type.ty
+  end
+
+  module Metadata : sig
+    type t = metadata
+
+    val t : t Irmin.Type.ty
+
+    val merge : t Irmin.Merge.t
+
+    val default : t
+  end
+
+  val step_t : branch Irmin.Type.ty
+
+  val key_t : key Irmin.Type.ty
+
+  val metadata_t : metadata Irmin.Type.ty
+
+  val contents_t : branch Irmin.Type.ty
+
+  val node_t : node Irmin.Type.ty
+
+  val tree_t : tree Irmin.Type.ty
+
+  val commit_t : repo -> commit Irmin.Type.ty
+
+  val branch_t : branch Irmin.Type.ty
+
+  val slice_t : slice Irmin.Type.ty
+
+  val kind_t : [`Contents | `Node] Irmin.Type.ty
+
+  val lca_error_t : lca_error Irmin.Type.ty
+
+  val ff_error_t : ff_error Irmin.Type.ty
+
+  module Private : sig
+    module Contents : sig
+      type t =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Contents.t
+
+      type key = Contents.hash
+
+      type value = branch
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      val merge : t -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : value -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Val : sig
+        type t = value
+
+        val t : t Irmin.Type.ty
+
+        val merge : t option Irmin.Merge.t
+      end
+    end
+
+    module Node : sig
+      type t =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Node.t
+
+      type key = Tree.Hash.t
+
+      type value =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Node.value
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      module Path : sig
+        type t = Key.t
+
+        type step = branch
+
+        val empty : t
+
+        val v : step list -> t
+
+        val is_empty : t -> bool
+
+        val cons : step -> t -> t
+
+        val rcons : t -> step -> t
+
+        val decons : t -> (step * t) option
+
+        val rdecons : t -> (t * step) option
+
+        val map : t -> (step -> 'a) -> 'a list
+
+        val t : t Irmin.Type.ty
+
+        val step_t : step Irmin.Type.ty
+      end
+
+      val merge : t -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : branch -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Metadata : sig
+        type t = metadata
+
+        val t : t Irmin.Type.ty
+
+        val merge : t Irmin.Merge.t
+
+        val default : t
+      end
+
+      module Val : sig
+        type t = value
+
+        type metadata = Metadata.t
+
+        type contents = Contents.key
+
+        type node = key
+
+        type step = branch
+
+        type value =
+          [ `Contents of contents * metadata
+          | `Node of node ]
+
+        val v : (step * value) list -> t
+
+        val list : t -> (step * value) list
+
+        val empty : t
+
+        val is_empty : t -> bool
+
+        val find : t -> step -> value option
+
+        val update : t -> step -> value -> t
+
+        val remove : t -> step -> t
+
+        val t : t Irmin.Type.ty
+
+        val metadata_t : metadata Irmin.Type.ty
+
+        val contents_t : contents Irmin.Type.ty
+
+        val node_t : node Irmin.Type.ty
+
+        val step_t : step Irmin.Type.ty
+
+        val value_t : value Irmin.Type.ty
+      end
+
+      module Contents : sig
+        type t =
+          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Node
+          .Contents
+          .t
+
+        type key = Val.contents
+
+        type value =
+          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Node
+          .Contents
+          .value
+
+        val mem : t -> key -> bool Lwt.t
+
+        val find : t -> key -> value option Lwt.t
+
+        val add : t -> value -> key Lwt.t
+
+        val merge : t -> key option Irmin.Merge.t
+
+        module Key : sig
+          type t = key
+
+          val digest : branch -> t
+
+          val hash : t -> int
+
+          val digest_size : int
+
+          val t : t Irmin.Type.ty
+        end
+
+        module Val : sig
+          type t = value
+
+          val t : t Irmin.Type.ty
+
+          val merge : t option Irmin.Merge.t
+        end
+      end
+    end
+
+    module Commit : sig
+      type t =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.t
+
+      type key = Commit.hash
+
+      type value =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit
+        .value
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      val merge : t -> info:Irmin.Info.f -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : branch -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Val : sig
+        type t = value
+
+        type commit = key
+
+        type node = Node.key
+
+        val v : info:Irmin.Info.t -> node:node -> parents:commit list -> t
+
+        val node : t -> node
+
+        val parents : t -> commit list
+
+        val info : t -> Irmin.Info.t
+
+        val t : t Irmin.Type.ty
+
+        val commit_t : commit Irmin.Type.ty
+
+        val node_t : node Irmin.Type.ty
+      end
+
+      module Node : sig
+        type t =
+          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit
+          .Node
+          .t
+
+        type key = Val.node
+
+        type value =
+          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit
+          .Node
+          .value
+
+        val mem : t -> key -> bool Lwt.t
+
+        val find : t -> key -> value option Lwt.t
+
+        val add : t -> value -> key Lwt.t
+
+        module Path : sig
+          type t =
+            Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit
+            .Node
+            .Path
+            .t
+
+          type step =
+            Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit
+            .Node
+            .Path
+            .step
+
+          val empty : t
+
+          val v : step list -> t
+
+          val is_empty : t -> bool
+
+          val cons : step -> t -> t
+
+          val rcons : t -> step -> t
+
+          val decons : t -> (step * t) option
+
+          val rdecons : t -> (t * step) option
+
+          val map : t -> (step -> 'a) -> 'a list
+
+          val t : t Irmin.Type.ty
+
+          val step_t : step Irmin.Type.ty
+        end
+
+        val merge : t -> key option Irmin.Merge.t
+
+        module Key : sig
+          type t = key
+
+          val digest : branch -> t
+
+          val hash : t -> int
+
+          val digest_size : int
+
+          val t : t Irmin.Type.ty
+        end
+
+        module Metadata : sig
+          type t =
+            Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit
+            .Node
+            .Metadata
+            .t
+
+          val t : t Irmin.Type.ty
+
+          val merge : t Irmin.Merge.t
+
+          val default : t
+        end
+
+        module Val : sig
+          type t = value
+
+          type metadata = Metadata.t
+
+          type contents =
+            Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit
+            .Node
+            .Val
+            .contents
+
+          type node = key
+
+          type step = Path.step
+
+          type value =
+            [ `Contents of contents * metadata
+            | `Node of node ]
+
+          val v : (step * value) list -> t
+
+          val list : t -> (step * value) list
+
+          val empty : t
+
+          val is_empty : t -> bool
+
+          val find : t -> step -> value option
+
+          val update : t -> step -> value -> t
+
+          val remove : t -> step -> t
+
+          val t : t Irmin.Type.ty
+
+          val metadata_t : metadata Irmin.Type.ty
+
+          val contents_t : contents Irmin.Type.ty
+
+          val node_t : node Irmin.Type.ty
+
+          val step_t : step Irmin.Type.ty
+
+          val value_t : value Irmin.Type.ty
+        end
+
+        module Contents : sig
+          type t =
+            Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit
+            .Node
+            .Contents
+            .t
+
+          type key = Val.contents
+
+          type value =
+            Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit
+            .Node
+            .Contents
+            .value
+
+          val mem : t -> key -> bool Lwt.t
+
+          val find : t -> key -> value option Lwt.t
+
+          val add : t -> value -> key Lwt.t
+
+          val merge : t -> key option Irmin.Merge.t
+
+          module Key : sig
+            type t = key
+
+            val digest : branch -> t
+
+            val hash : t -> int
+
+            val digest_size : int
+
+            val t : t Irmin.Type.ty
+          end
+
+          module Val : sig
+            type t = value
+
+            val t : t Irmin.Type.ty
+
+            val merge : t option Irmin.Merge.t
+          end
+        end
+      end
+    end
+
+    module Branch : sig
+      type t =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Branch.t
+
+      type key = branch
+
+      type value = Commit.key
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val set : t -> key -> value -> unit Lwt.t
+
+      val test_and_set :
+        t -> key -> test:value option -> set:value option -> bool Lwt.t
+
+      val remove : t -> key -> unit Lwt.t
+
+      type watch =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Branch
+        .watch
+
+      val watch :
+        t ->
+        ?init:(key * value) list ->
+        (key -> value Irmin.diff -> unit Lwt.t) ->
+        watch Lwt.t
+
+      val watch_key :
+        t ->
+        key ->
+        ?init:value ->
+        (value Irmin.diff -> unit Lwt.t) ->
+        watch Lwt.t
+
+      val unwatch : t -> watch -> unit Lwt.t
+
+      val list : t -> key list Lwt.t
+
+      module Key : sig
+        type t = key
+
+        val t : t Irmin.Type.ty
+
+        val master : t
+
+        val is_valid : t -> bool
+      end
+
+      module Val : sig
+        type t = value
+
+        val digest : key -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+    end
+
+    module Slice : sig
+      type t = slice
+
+      type contents = Contents.key * branch
+
+      type node = Node.key * Node.value
+
+      type commit = Branch.value * Commit.value
+
+      type value =
+        [ `Commit of commit
+        | `Contents of contents
+        | `Node of node ]
+
+      val empty : unit -> t Lwt.t
+
+      val add : t -> value -> unit Lwt.t
+
+      val iter : t -> (value -> unit Lwt.t) -> unit Lwt.t
+
+      val t : t Irmin.Type.ty
+
+      val contents_t : contents Irmin.Type.ty
+
+      val node_t : node Irmin.Type.ty
+
+      val commit_t : commit Irmin.Type.ty
+
+      val value_t : value Irmin.Type.ty
+    end
+
+    module Repo : sig
+      type t = repo
+
+      val v : Irmin.config -> t Lwt.t
+
+      val contents_t : t -> Contents.t
+
+      val node_t : t -> Node.t
+
+      val commit_t : t -> Commit.t
+
+      val branch_t : t -> Branch.t
+    end
+
+    module Sync : sig
+      type t =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Sync.t
+
+      type commit = Branch.value
+
       type branch = contents
-      type slice = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).slice
-      type lca_error = [ `Max_depth_reached | `Too_many_lcas ]
-      type ff_error =
-          [ `Max_depth_reached | `No_change | `Rejected | `Too_many_lcas ]
-      module Repo :
-        sig
-          type t = repo
-          val v : Irmin.config -> t Lwt.t
-          val heads : t -> commit list Lwt.t
-          val branches : t -> branch list Lwt.t
-          val export :
-            ?full:bool ->
-            ?depth:int ->
-            ?min:commit list -> ?max:commit list -> t -> slice Lwt.t
-          val import : t -> slice -> (unit, [ `Msg of branch ]) result Lwt.t
-        end
-      val empty : repo -> t Lwt.t
-      val master : repo -> t Lwt.t
-      val of_branch : repo -> branch -> t Lwt.t
-      val of_commit : commit -> t Lwt.t
-      val repo : t -> repo
-      val tree : t -> tree Lwt.t
-      module Status :
-        sig
-          type t = [ `Branch of branch | `Commit of commit | `Empty ]
-          val t : repo -> t Irmin.Type.ty
-          val pp : t Fmt.t
-        end
-      val status : t -> Status.t
-      module Head :
-        sig
-          val list : repo -> commit list Lwt.t
-          val find : t -> commit option Lwt.t
-          val get : t -> commit Lwt.t
-          val set : t -> commit -> unit Lwt.t
-          val fast_forward :
-            t ->
-            ?max_depth:int ->
-            ?n:int ->
-            commit ->
-            (unit,
-             [ `Max_depth_reached | `No_change | `Rejected | `Too_many_lcas ])
-            result Lwt.t
-          val test_and_set :
-            t -> test:commit option -> set:commit option -> bool Lwt.t
-          val merge :
-            into:t ->
-            info:Irmin.Info.f ->
-            ?max_depth:int ->
-            ?n:int -> commit -> (unit, Irmin.Merge.conflict) result Lwt.t
-        end
-      module Commit :
-        sig
-          type t = commit
-          val t : repo -> t Irmin.Type.ty
-          val pp_hash : t Fmt.t
-          val v :
-            repo -> info:Irmin.Info.t -> parents:t list -> tree -> t Lwt.t
-          val tree : t -> tree Lwt.t
-          val parents : t -> t list Lwt.t
-          val info : t -> Irmin.Info.t
-          module Hash :
-            sig
-              type t =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Commit.Hash.t
-              val digest : branch -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = Hash.t
-          val hash : t -> hash
-          val of_hash : repo -> hash -> t option Lwt.t
-        end
-      module Contents :
-        sig
-          type t = branch
-          val t : t Irmin.Type.ty
-          val merge : t option Irmin.Merge.t
-          module Hash :
-            sig
-              type t =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Contents.Hash.t
-              val digest : branch -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = Hash.t
-          val hash : repo -> t -> hash Lwt.t
-          val of_hash : repo -> hash -> t option Lwt.t
-        end
-      module Tree :
-        sig
-          val empty : tree
-          val of_contents : ?metadata:metadata -> branch -> tree
-          val of_node : node -> tree
-          val kind : tree -> key -> [ `Contents | `Node ] option Lwt.t
-          val list :
-            tree -> key -> (branch * [ `Contents | `Node ]) list Lwt.t
-          val diff :
-            tree -> tree -> (key * (branch * metadata) Irmin.diff) list Lwt.t
-          val mem : tree -> key -> bool Lwt.t
-          val find_all : tree -> key -> (branch * metadata) option Lwt.t
-          val find : tree -> key -> branch option Lwt.t
-          val get_all : tree -> key -> (branch * metadata) Lwt.t
-          val get : tree -> key -> branch Lwt.t
-          val add : tree -> key -> ?metadata:metadata -> branch -> tree Lwt.t
-          val remove : tree -> key -> tree Lwt.t
-          val mem_tree : tree -> key -> bool Lwt.t
-          val find_tree : tree -> key -> tree option Lwt.t
-          val get_tree : tree -> key -> tree Lwt.t
-          val add_tree : tree -> key -> tree -> tree Lwt.t
-          val merge : tree Irmin.Merge.t
-          val clear_caches : tree -> unit
-          type marks =
-              Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Tree.marks
-          val empty_marks : unit -> marks
-          type 'a force = [ `False of key -> 'a -> 'a Lwt.t | `True ]
-          type uniq = [ `False | `Marks of marks | `True ]
-          type 'a node_fn = key -> branch list -> 'a -> 'a Lwt.t
-          val fold :
-            ?force:'a force ->
-            ?uniq:uniq ->
-            ?pre:'a node_fn ->
-            ?post:'a node_fn ->
-            (key -> branch -> 'a -> 'a Lwt.t) -> tree -> 'a -> 'a Lwt.t
-          type stats =
-            Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Tree.stats = {
-            nodes : int;
-            leafs : int;
-            skips : int;
-            depth : int;
-            width : int;
-          }
-          val pp_stats : stats Fmt.t
-          val stats : ?force:bool -> tree -> stats Lwt.t
-          type concrete =
-              [ `Contents of branch * metadata
-              | `Tree of (branch * concrete) list ]
-          val of_concrete : concrete -> tree
-          val to_concrete : tree -> concrete Lwt.t
-          module Hash :
-            sig
-              type t =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Tree.Hash.t
-              val digest : branch -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash =
-              [ `Contents of Contents.hash * metadata | `Node of Hash.t ]
-          val hash_t : hash Irmin.Type.ty
-          val hash : repo -> tree -> hash Lwt.t
-          val of_hash : repo -> hash -> tree option Lwt.t
-        end
-      val kind : t -> key -> [ `Contents | `Node ] option Lwt.t
-      val list : t -> key -> (branch * [ `Contents | `Node ]) list Lwt.t
-      val mem : t -> key -> bool Lwt.t
-      val mem_tree : t -> key -> bool Lwt.t
-      val find_all : t -> key -> (branch * metadata) option Lwt.t
-      val find : t -> key -> branch option Lwt.t
-      val get_all : t -> key -> (branch * metadata) Lwt.t
-      val get : t -> key -> branch Lwt.t
-      val find_tree : t -> key -> tree option Lwt.t
-      val get_tree : t -> key -> tree Lwt.t
-      type 'a transaction =
-          ?retries:int ->
-          ?allow_empty:bool ->
-          ?strategy:[ `Merge_with_parent of commit | `Set | `Test_and_set ] ->
-          info:Irmin.Info.f -> 'a -> unit Lwt.t
-      val with_tree :
-        t -> key -> (tree option -> tree option Lwt.t) transaction
-      val set : t -> key -> ?metadata:metadata -> branch transaction
-      val set_tree : t -> key -> tree transaction
-      val remove : t -> key transaction
-      val clone : src:t -> dst:branch -> t Lwt.t
-      type watch = Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).watch
-      val watch :
-        t -> ?init:commit -> (commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-      val watch_key :
+
+      type endpoint =
+        Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Sync
+        .endpoint
+
+      val fetch :
         t ->
-        key ->
-        ?init:commit ->
-        ((commit * tree) Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-      val unwatch : watch -> unit Lwt.t
-      type 'a merge =
-          info:Irmin.Info.f ->
-          ?max_depth:int ->
-          ?n:int -> 'a -> (unit, Irmin.Merge.conflict) result Lwt.t
-      val merge : into:t -> t merge
-      val merge_with_branch : t -> branch merge
-      val merge_with_commit : t -> commit merge
-      val lcas :
-        ?max_depth:int ->
-        ?n:int -> t -> t -> (commit list, lca_error) result Lwt.t
-      val lcas_with_branch :
-        t ->
-        ?max_depth:int ->
-        ?n:int -> branch -> (commit list, lca_error) result Lwt.t
-      val lcas_with_commit :
-        t ->
-        ?max_depth:int ->
-        ?n:int -> commit -> (commit list, lca_error) result Lwt.t
-      module History :
-        sig
-          type t =
-              Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).History.t
-          module V :
-            sig
-              type t = commit
-              val compare : t -> t -> int
-              val hash : t -> int
-              val equal : t -> t -> bool
-              type label =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).History.V.label
-              val create : label -> t
-              val label : t -> label
-            end
-          type vertex = commit
-          module E :
-            sig
-              type t =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).History.E.t
-              val compare : t -> t -> int
-              type vertex = commit
-              val src : t -> vertex
-              val dst : t -> vertex
-              type label =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).History.E.label
-              val create : vertex -> label -> vertex -> t
-              val label : t -> label
-            end
-          type edge = E.t
-          val is_directed : bool
-          val is_empty : t -> bool
-          val nb_vertex : t -> int
-          val nb_edges : t -> int
-          val out_degree : t -> vertex -> int
-          val in_degree : t -> vertex -> int
-          val mem_vertex : t -> vertex -> bool
-          val mem_edge : t -> vertex -> vertex -> bool
-          val mem_edge_e : t -> edge -> bool
-          val find_edge : t -> vertex -> vertex -> edge
-          val find_all_edges : t -> vertex -> vertex -> edge list
-          val succ : t -> vertex -> vertex list
-          val pred : t -> vertex -> vertex list
-          val succ_e : t -> vertex -> edge list
-          val pred_e : t -> vertex -> edge list
-          val iter_vertex : (vertex -> unit) -> t -> unit
-          val fold_vertex : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
-          val iter_edges : (vertex -> vertex -> unit) -> t -> unit
-          val fold_edges : (vertex -> vertex -> 'a -> 'a) -> t -> 'a -> 'a
-          val iter_edges_e : (edge -> unit) -> t -> unit
-          val fold_edges_e : (edge -> 'a -> 'a) -> t -> 'a -> 'a
-          val map_vertex : (vertex -> vertex) -> t -> t
-          val iter_succ : (vertex -> unit) -> t -> vertex -> unit
-          val iter_pred : (vertex -> unit) -> t -> vertex -> unit
-          val fold_succ : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val fold_pred : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val iter_succ_e : (edge -> unit) -> t -> vertex -> unit
-          val fold_succ_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val iter_pred_e : (edge -> unit) -> t -> vertex -> unit
-          val fold_pred_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val empty : t
-          val add_vertex : t -> vertex -> t
-          val remove_vertex : t -> vertex -> t
-          val add_edge : t -> vertex -> vertex -> t
-          val add_edge_e : t -> edge -> t
-          val remove_edge : t -> vertex -> vertex -> t
-          val remove_edge_e : t -> edge -> t
-        end
-      val history :
         ?depth:int ->
-        ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
-      module Branch :
-        sig
-          val mem : repo -> branch -> bool Lwt.t
-          val find : repo -> branch -> commit option Lwt.t
-          val get : repo -> branch -> commit Lwt.t
-          val set : repo -> branch -> commit -> unit Lwt.t
-          val remove : repo -> branch -> unit Lwt.t
-          val list : repo -> branch list Lwt.t
-          val watch :
-            repo ->
-            branch ->
-            ?init:commit -> (commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-          val watch_all :
-            repo ->
-            ?init:(branch * commit) list ->
-            (branch -> commit Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-          type t = branch
-          val t : t Irmin.Type.ty
-          val master : t
-          val is_valid : t -> bool
-        end
-      module Key :
-        sig
-          type t = key
-          type step = branch
-          val empty : t
-          val v : step list -> t
-          val is_empty : t -> bool
-          val cons : step -> t -> t
-          val rcons : t -> step -> t
-          val decons : t -> (step * t) option
-          val rdecons : t -> (t * step) option
-          val map : t -> (step -> 'a) -> 'a list
-          val t : t Irmin.Type.ty
-          val step_t : step Irmin.Type.ty
-        end
-      module Metadata :
-        sig
-          type t = metadata
-          val t : t Irmin.Type.ty
-          val merge : t Irmin.Merge.t
-          val default : t
-        end
-      val step_t : branch Irmin.Type.ty
-      val key_t : key Irmin.Type.ty
-      val metadata_t : metadata Irmin.Type.ty
-      val contents_t : branch Irmin.Type.ty
-      val node_t : node Irmin.Type.ty
-      val tree_t : tree Irmin.Type.ty
-      val commit_t : repo -> commit Irmin.Type.ty
-      val branch_t : branch Irmin.Type.ty
-      val slice_t : slice Irmin.Type.ty
-      val kind_t : [ `Contents | `Node ] Irmin.Type.ty
-      val lca_error_t : lca_error Irmin.Type.ty
-      val ff_error_t : ff_error Irmin.Type.ty
-      module Private :
-        sig
-          module Contents :
-            sig
-              type t =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Contents.t
-              type key = Contents.hash
-              type value = branch
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              val merge : t -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : value -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Val :
-                sig
-                  type t = value
-                  val t : t Irmin.Type.ty
-                  val merge : t option Irmin.Merge.t
-                end
-            end
-          module Node :
-            sig
-              type t =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Node.t
-              type key = Tree.Hash.t
-              type value =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Node.value
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              module Path :
-                sig
-                  type t = Key.t
-                  type step = branch
-                  val empty : t
-                  val v : step list -> t
-                  val is_empty : t -> bool
-                  val cons : step -> t -> t
-                  val rcons : t -> step -> t
-                  val decons : t -> (step * t) option
-                  val rdecons : t -> (t * step) option
-                  val map : t -> (step -> 'a) -> 'a list
-                  val t : t Irmin.Type.ty
-                  val step_t : step Irmin.Type.ty
-                end
-              val merge : t -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : branch -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Metadata :
-                sig
-                  type t = metadata
-                  val t : t Irmin.Type.ty
-                  val merge : t Irmin.Merge.t
-                  val default : t
-                end
-              module Val :
-                sig
-                  type t = value
-                  type metadata = Metadata.t
-                  type contents = Contents.key
-                  type node = key
-                  type step = branch
-                  type value =
-                      [ `Contents of contents * metadata | `Node of node ]
-                  val v : (step * value) list -> t
-                  val list : t -> (step * value) list
-                  val empty : t
-                  val is_empty : t -> bool
-                  val find : t -> step -> value option
-                  val update : t -> step -> value -> t
-                  val remove : t -> step -> t
-                  val t : t Irmin.Type.ty
-                  val metadata_t : metadata Irmin.Type.ty
-                  val contents_t : contents Irmin.Type.ty
-                  val node_t : node Irmin.Type.ty
-                  val step_t : step Irmin.Type.ty
-                  val value_t : value Irmin.Type.ty
-                end
-              module Contents :
-                sig
-                  type t =
-                      Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Node.Contents.t
-                  type key = Val.contents
-                  type value =
-                      Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Node.Contents.value
-                  val mem : t -> key -> bool Lwt.t
-                  val find : t -> key -> value option Lwt.t
-                  val add : t -> value -> key Lwt.t
-                  val merge : t -> key option Irmin.Merge.t
-                  module Key :
-                    sig
-                      type t = key
-                      val digest : branch -> t
-                      val hash : t -> int
-                      val digest_size : int
-                      val t : t Irmin.Type.ty
-                    end
-                  module Val :
-                    sig
-                      type t = value
-                      val t : t Irmin.Type.ty
-                      val merge : t option Irmin.Merge.t
-                    end
-                end
-            end
-          module Commit :
-            sig
-              type t =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.t
-              type key = Commit.hash
-              type value =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.value
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              val merge : t -> info:Irmin.Info.f -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : branch -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Val :
-                sig
-                  type t = value
-                  type commit = key
-                  type node = Node.key
-                  val v :
-                    info:Irmin.Info.t ->
-                    node:node -> parents:commit list -> t
-                  val node : t -> node
-                  val parents : t -> commit list
-                  val info : t -> Irmin.Info.t
-                  val t : t Irmin.Type.ty
-                  val commit_t : commit Irmin.Type.ty
-                  val node_t : node Irmin.Type.ty
-                end
-              module Node :
-                sig
-                  type t =
-                      Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.Node.t
-                  type key = Val.node
-                  type value =
-                      Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.Node.value
-                  val mem : t -> key -> bool Lwt.t
-                  val find : t -> key -> value option Lwt.t
-                  val add : t -> value -> key Lwt.t
-                  module Path :
-                    sig
-                      type t =
-                          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.Node.Path.t
-                      type step =
-                          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.Node.Path.step
-                      val empty : t
-                      val v : step list -> t
-                      val is_empty : t -> bool
-                      val cons : step -> t -> t
-                      val rcons : t -> step -> t
-                      val decons : t -> (step * t) option
-                      val rdecons : t -> (t * step) option
-                      val map : t -> (step -> 'a) -> 'a list
-                      val t : t Irmin.Type.ty
-                      val step_t : step Irmin.Type.ty
-                    end
-                  val merge : t -> key option Irmin.Merge.t
-                  module Key :
-                    sig
-                      type t = key
-                      val digest : branch -> t
-                      val hash : t -> int
-                      val digest_size : int
-                      val t : t Irmin.Type.ty
-                    end
-                  module Metadata :
-                    sig
-                      type t =
-                          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.Node.Metadata.t
-                      val t : t Irmin.Type.ty
-                      val merge : t Irmin.Merge.t
-                      val default : t
-                    end
-                  module Val :
-                    sig
-                      type t = value
-                      type metadata = Metadata.t
-                      type contents =
-                          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.Node.Val.contents
-                      type node = key
-                      type step = Path.step
-                      type value =
-                          [ `Contents of contents * metadata | `Node of node ]
-                      val v : (step * value) list -> t
-                      val list : t -> (step * value) list
-                      val empty : t
-                      val is_empty : t -> bool
-                      val find : t -> step -> value option
-                      val update : t -> step -> value -> t
-                      val remove : t -> step -> t
-                      val t : t Irmin.Type.ty
-                      val metadata_t : metadata Irmin.Type.ty
-                      val contents_t : contents Irmin.Type.ty
-                      val node_t : node Irmin.Type.ty
-                      val step_t : step Irmin.Type.ty
-                      val value_t : value Irmin.Type.ty
-                    end
-                  module Contents :
-                    sig
-                      type t =
-                          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.Node.Contents.t
-                      type key = Val.contents
-                      type value =
-                          Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Commit.Node.Contents.value
-                      val mem : t -> key -> bool Lwt.t
-                      val find : t -> key -> value option Lwt.t
-                      val add : t -> value -> key Lwt.t
-                      val merge : t -> key option Irmin.Merge.t
-                      module Key :
-                        sig
-                          type t = key
-                          val digest : branch -> t
-                          val hash : t -> int
-                          val digest_size : int
-                          val t : t Irmin.Type.ty
-                        end
-                      module Val :
-                        sig
-                          type t = value
-                          val t : t Irmin.Type.ty
-                          val merge : t option Irmin.Merge.t
-                        end
-                    end
-                end
-            end
-          module Branch :
-            sig
-              type t =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Branch.t
-              type key = branch
-              type value = Commit.key
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val set : t -> key -> value -> unit Lwt.t
-              val test_and_set :
-                t ->
-                key -> test:value option -> set:value option -> bool Lwt.t
-              val remove : t -> key -> unit Lwt.t
-              type watch =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Branch.watch
-              val watch :
-                t ->
-                ?init:(key * value) list ->
-                (key -> value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-              val watch_key :
-                t ->
-                key ->
-                ?init:value ->
-                (value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-              val unwatch : t -> watch -> unit Lwt.t
-              val list : t -> key list Lwt.t
-              module Key :
-                sig
-                  type t = key
-                  val t : t Irmin.Type.ty
-                  val master : t
-                  val is_valid : t -> bool
-                end
-              module Val :
-                sig
-                  type t = value
-                  val digest : key -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-            end
-          module Slice :
-            sig
-              type t = slice
-              type contents = Contents.key * branch
-              type node = Node.key * Node.value
-              type commit = Branch.value * Commit.value
-              type value =
-                  [ `Commit of commit | `Contents of contents | `Node of node ]
-              val empty : unit -> t Lwt.t
-              val add : t -> value -> unit Lwt.t
-              val iter : t -> (value -> unit Lwt.t) -> unit Lwt.t
-              val t : t Irmin.Type.ty
-              val contents_t : contents Irmin.Type.ty
-              val node_t : node Irmin.Type.ty
-              val commit_t : commit Irmin.Type.ty
-              val value_t : value Irmin.Type.ty
-            end
-          module Repo :
-            sig
-              type t = repo
-              val v : Irmin.config -> t Lwt.t
-              val contents_t : t -> Contents.t
-              val node_t : t -> Node.t
-              val commit_t : t -> Commit.t
-              val branch_t : t -> Branch.t
-            end
-          module Sync :
-            sig
-              type t =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Sync.t
-              type commit = Branch.value
-              type branch = contents
-              type endpoint =
-                  Irmin_git.Generic_KV(AO)(RW)(Irmin.Contents.String).Private.Sync.endpoint
-              val fetch :
-                t ->
-                ?depth:int ->
-                endpoint ->
-                branch ->
-                (commit, [ `Msg of branch | `No_head | `Not_available ])
-                result Lwt.t
-              val push :
-                t ->
-                ?depth:int ->
-                endpoint ->
-                branch ->
-                (unit,
-                 [ `Detached_head
-                 | `Msg of branch
-                 | `No_head
-                 | `Not_available ])
-                result Lwt.t
-              val v : repo -> t Lwt.t
-            end
-        end
-      type Irmin.remote += E of Private.Sync.endpoint
-      val flush : DB.t -> int64 Lwt.t
+        endpoint ->
+        branch ->
+        (commit, [`Msg of branch | `No_head | `Not_available]) result Lwt.t
+
+      val push :
+        t ->
+        ?depth:int ->
+        endpoint ->
+        branch ->
+        ( unit,
+          [`Detached_head | `Msg of branch | `No_head | `Not_available] )
+        result
+        Lwt.t
+
+      val v : repo -> t Lwt.t
     end
-module KV_chunked :
-  functor (DB : DB) (C : Irmin.Contents.S) ->
-    sig
-      module AO :
-        functor (K : Irmin.Hash.S) (V : Irmin.Type.S) ->
-          sig
-            type t = Irmin_chunk.AO(AO_BUILDER(DB))(K)(V).t
-            type key = K.t
-            type value = V.t
-            val mem : t -> key -> bool Lwt.t
-            val find : t -> key -> value option Lwt.t
-            val add : t -> value -> key Lwt.t
-            val v : Irmin.config -> t Lwt.t
-          end
-      module DB :
-        sig
-          module Stor : Wodan.S
-          type t = DB.t
-          val db_root : t -> Stor.root
-          val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-          val v : Irmin.config -> t Lwt.t
-          val flush : t -> int64 Lwt.t
-        end
-      module RW :
-        functor (K : Irmin.Type.S) (V : Irmin.Type.S) ->
-          sig
-            type t = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).t
-            type key = K.t
-            type value = V.t
-            val mem : t -> key -> bool Lwt.t
-            val find : t -> key -> value option Lwt.t
-            val set : t -> key -> value -> unit Lwt.t
-            val test_and_set :
-              t -> key -> test:value option -> set:value option -> bool Lwt.t
-            val remove : t -> key -> unit Lwt.t
-            val list : t -> key list Lwt.t
-            type watch = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).watch
-            val watch :
-              t ->
-              ?init:(key * value) list ->
-              (key -> value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-            val watch_key :
-              t ->
-              key ->
-              ?init:value -> (value Irmin.diff -> unit Lwt.t) -> watch Lwt.t
-            val unwatch : t -> watch -> unit Lwt.t
-            val v : Irmin.config -> t Lwt.t
-          end
-      type repo =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).repo
+  end
+
+  type Irmin.remote += E of Private.Sync.endpoint
+
+  val flush : DB.t -> int64 Lwt.t
+end
+
+module KV_chunked (DB : DB) (C : Irmin.Contents.S) : sig
+  module AO (K : Irmin.Hash.S) (V : Irmin.Type.S) : sig
+    type t = Irmin_chunk.AO(AO_BUILDER(DB))(K)(V).t
+
+    type key = K.t
+
+    type value = V.t
+
+    val mem : t -> key -> bool Lwt.t
+
+    val find : t -> key -> value option Lwt.t
+
+    val add : t -> value -> key Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+  end
+
+  module DB : sig
+    module Stor : Wodan.S
+
+    type t = DB.t
+
+    val db_root : t -> Stor.root
+
+    val may_autoflush : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+
+    val flush : t -> int64 Lwt.t
+  end
+
+  module RW (K : Irmin.Type.S) (V : Irmin.Type.S) : sig
+    type t = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).t
+
+    type key = K.t
+
+    type value = V.t
+
+    val mem : t -> key -> bool Lwt.t
+
+    val find : t -> key -> value option Lwt.t
+
+    val set : t -> key -> value -> unit Lwt.t
+
+    val test_and_set :
+      t -> key -> test:value option -> set:value option -> bool Lwt.t
+
+    val remove : t -> key -> unit Lwt.t
+
+    val list : t -> key list Lwt.t
+
+    type watch = RW_BUILDER(DB)(Irmin.Hash.SHA1)(K)(V).watch
+
+    val watch :
+      t ->
+      ?init:(key * value) list ->
+      (key -> value Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val watch_key :
+      t ->
+      key ->
+      ?init:value ->
+      (value Irmin.diff -> unit Lwt.t) ->
+      watch Lwt.t
+
+    val unwatch : t -> watch -> unit Lwt.t
+
+    val v : Irmin.config -> t Lwt.t
+  end
+
+  type repo =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .repo
+
+  type t =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .t
+
+  type step = string
+
+  type key = Irmin.Path.String_list.t
+
+  type metadata = unit
+
+  type contents = C.t
+
+  type node =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .node
+
+  type tree =
+    [ `Contents of contents * metadata
+    | `Node of node ]
+
+  type commit =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .commit
+
+  type branch = step
+
+  type slice =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .slice
+
+  type lca_error =
+    [ `Max_depth_reached
+    | `Too_many_lcas ]
+
+  type ff_error =
+    [ `Max_depth_reached
+    | `No_change
+    | `Rejected
+    | `Too_many_lcas ]
+
+  module Repo : sig
+    type t = repo
+
+    val v : Irmin.config -> t Lwt.t
+
+    val heads : t -> commit list Lwt.t
+
+    val branches : t -> branch list Lwt.t
+
+    val export :
+      ?full:bool ->
+      ?depth:int ->
+      ?min:commit list ->
+      ?max:commit list ->
+      t ->
+      slice Lwt.t
+
+    val import : t -> slice -> (metadata, [`Msg of branch]) result Lwt.t
+  end
+
+  val empty : repo -> t Lwt.t
+
+  val master : repo -> t Lwt.t
+
+  val of_branch : repo -> branch -> t Lwt.t
+
+  val of_commit : commit -> t Lwt.t
+
+  val repo : t -> repo
+
+  val tree : t -> tree Lwt.t
+
+  module Status : sig
+    type t =
+      [ `Branch of branch
+      | `Commit of commit
+      | `Empty ]
+
+    val t : repo -> t Irmin.Type.ty
+
+    val pp : t Fmt.t
+  end
+
+  val status : t -> Status.t
+
+  module Head : sig
+    val list : repo -> commit list Lwt.t
+
+    val find : t -> commit option Lwt.t
+
+    val get : t -> commit Lwt.t
+
+    val set : t -> commit -> metadata Lwt.t
+
+    val fast_forward :
+      t ->
+      ?max_depth:int ->
+      ?n:int ->
+      commit ->
+      ( metadata,
+        [`Max_depth_reached | `No_change | `Rejected | `Too_many_lcas] )
+      result
+      Lwt.t
+
+    val test_and_set :
+      t -> test:commit option -> set:commit option -> bool Lwt.t
+
+    val merge :
+      into:t ->
+      info:Irmin.Info.f ->
+      ?max_depth:int ->
+      ?n:int ->
+      commit ->
+      (metadata, Irmin.Merge.conflict) result Lwt.t
+  end
+
+  module Commit : sig
+    type t = commit
+
+    val t : repo -> t Irmin.Type.ty
+
+    val pp_hash : t Fmt.t
+
+    val v : repo -> info:Irmin.Info.t -> parents:t list -> tree -> t Lwt.t
+
+    val tree : t -> tree Lwt.t
+
+    val parents : t -> t list Lwt.t
+
+    val info : t -> Irmin.Info.t
+
+    module Hash : sig
+      type t = Irmin.Hash.SHA1.t
+
+      val digest : branch -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash = Hash.t
+
+    val hash : t -> hash
+
+    val of_hash : repo -> hash -> t option Lwt.t
+  end
+
+  module Contents : sig
+    type t = contents
+
+    val t : t Irmin.Type.ty
+
+    val merge : t option Irmin.Merge.t
+
+    module Hash : sig
+      type t = Commit.hash
+
+      val digest : branch -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash = Hash.t
+
+    val hash : repo -> t -> hash Lwt.t
+
+    val of_hash : repo -> hash -> t option Lwt.t
+  end
+
+  module Tree : sig
+    val empty : tree
+
+    val of_contents : ?metadata:metadata -> contents -> tree
+
+    val of_node : node -> tree
+
+    val kind : tree -> key -> [`Contents | `Node] option Lwt.t
+
+    val list : tree -> key -> (branch * [`Contents | `Node]) list Lwt.t
+
+    val diff :
+      tree -> tree -> (key * (contents * metadata) Irmin.diff) list Lwt.t
+
+    val mem : tree -> key -> bool Lwt.t
+
+    val find_all : tree -> key -> (contents * metadata) option Lwt.t
+
+    val find : tree -> key -> contents option Lwt.t
+
+    val get_all : tree -> key -> (contents * metadata) Lwt.t
+
+    val get : tree -> key -> contents Lwt.t
+
+    val add : tree -> key -> ?metadata:metadata -> contents -> tree Lwt.t
+
+    val remove : tree -> key -> tree Lwt.t
+
+    val mem_tree : tree -> key -> bool Lwt.t
+
+    val find_tree : tree -> key -> tree option Lwt.t
+
+    val get_tree : tree -> key -> tree Lwt.t
+
+    val add_tree : tree -> key -> tree -> tree Lwt.t
+
+    val merge : tree Irmin.Merge.t
+
+    val clear_caches : tree -> metadata
+
+    type marks =
+      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+        (Irmin.Branch.String)
+        (Irmin.Hash.SHA1)
+      .Tree
+      .marks
+
+    val empty_marks : metadata -> marks
+
+    type 'a force =
+      [ `False of key -> 'a -> 'a Lwt.t
+      | `True ]
+
+    type uniq =
+      [ `False
+      | `Marks of marks
+      | `True ]
+
+    type 'a node_fn = key -> branch list -> 'a -> 'a Lwt.t
+
+    val fold :
+      ?force:'a force ->
+      ?uniq:uniq ->
+      ?pre:'a node_fn ->
+      ?post:'a node_fn ->
+      (key -> contents -> 'a -> 'a Lwt.t) ->
+      tree ->
+      'a ->
+      'a Lwt.t
+
+    type stats =
+                Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)
+                  (Irmin.Path.String_list)
+                  (Irmin.Branch.String)
+                  (Irmin.Hash.SHA1)
+                .Tree
+                .stats = {
+      nodes : int;
+      leafs : int;
+      skips : int;
+      depth : int;
+      width : int
+    }
+
+    val pp_stats : stats Fmt.t
+
+    val stats : ?force:bool -> tree -> stats Lwt.t
+
+    type concrete =
+      [ `Contents of contents * metadata
+      | `Tree of (branch * concrete) list ]
+
+    val of_concrete : concrete -> tree
+
+    val to_concrete : tree -> concrete Lwt.t
+
+    module Hash : sig
+      type t = Contents.hash
+
+      val digest : branch -> t
+
+      val hash : t -> int
+
+      val digest_size : int
+
+      val t : t Irmin.Type.ty
+    end
+
+    type hash =
+      [ `Contents of Hash.t * metadata
+      | `Node of Hash.t ]
+
+    val hash_t : hash Irmin.Type.ty
+
+    val hash : repo -> tree -> hash Lwt.t
+
+    val of_hash : repo -> hash -> tree option Lwt.t
+  end
+
+  val kind : t -> key -> [`Contents | `Node] option Lwt.t
+
+  val list : t -> key -> (branch * [`Contents | `Node]) list Lwt.t
+
+  val mem : t -> key -> bool Lwt.t
+
+  val mem_tree : t -> key -> bool Lwt.t
+
+  val find_all : t -> key -> (contents * metadata) option Lwt.t
+
+  val find : t -> key -> contents option Lwt.t
+
+  val get_all : t -> key -> (contents * metadata) Lwt.t
+
+  val get : t -> key -> contents Lwt.t
+
+  val find_tree : t -> key -> tree option Lwt.t
+
+  val get_tree : t -> key -> tree Lwt.t
+
+  type 'a transaction =
+    ?retries:int ->
+    ?allow_empty:bool ->
+    ?strategy:[`Merge_with_parent of commit | `Set | `Test_and_set] ->
+    info:Irmin.Info.f ->
+    'a ->
+    metadata Lwt.t
+
+  val with_tree : t -> key -> (tree option -> tree option Lwt.t) transaction
+
+  val set : t -> key -> ?metadata:metadata -> contents transaction
+
+  val set_tree : t -> key -> tree transaction
+
+  val remove : t -> key transaction
+
+  val clone : src:t -> dst:branch -> t Lwt.t
+
+  type watch =
+    Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Irmin.Hash.SHA1)
+    .watch
+
+  val watch :
+    t -> ?init:commit -> (commit Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
+
+  val watch_key :
+    t ->
+    key ->
+    ?init:commit ->
+    ((commit * tree) Irmin.diff -> metadata Lwt.t) ->
+    watch Lwt.t
+
+  val unwatch : watch -> metadata Lwt.t
+
+  type 'a merge =
+    info:Irmin.Info.f ->
+    ?max_depth:int ->
+    ?n:int ->
+    'a ->
+    (metadata, Irmin.Merge.conflict) result Lwt.t
+
+  val merge : into:t -> t merge
+
+  val merge_with_branch : t -> branch merge
+
+  val merge_with_commit : t -> commit merge
+
+  val lcas :
+    ?max_depth:int ->
+    ?n:int ->
+    t ->
+    t ->
+    (commit list, lca_error) result Lwt.t
+
+  val lcas_with_branch :
+    t ->
+    ?max_depth:int ->
+    ?n:int ->
+    branch ->
+    (commit list, lca_error) result Lwt.t
+
+  val lcas_with_commit :
+    t ->
+    ?max_depth:int ->
+    ?n:int ->
+    commit ->
+    (commit list, lca_error) result Lwt.t
+
+  module History : sig
+    type t =
+      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+        (Irmin.Branch.String)
+        (Irmin.Hash.SHA1)
+      .History
+      .t
+
+    module V : sig
+      type t = commit
+
+      val compare : t -> t -> int
+
+      val hash : t -> int
+
+      val equal : t -> t -> bool
+
+      type label =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .History
+        .V
+        .label
+
+      val create : label -> t
+
+      val label : t -> label
+    end
+
+    type vertex = commit
+
+    module E : sig
       type t =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).t
-      type step = string
-      type key = Irmin.Path.String_list.t
-      type metadata = unit
-      type contents = C.t
-      type node =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).node
-      type tree = [ `Contents of contents * metadata | `Node of node ]
-      type commit =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).commit
-      type branch = step
-      type slice =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).slice
-      type lca_error = [ `Max_depth_reached | `Too_many_lcas ]
-      type ff_error =
-          [ `Max_depth_reached | `No_change | `Rejected | `Too_many_lcas ]
-      module Repo :
-        sig
-          type t = repo
-          val v : Irmin.config -> t Lwt.t
-          val heads : t -> commit list Lwt.t
-          val branches : t -> branch list Lwt.t
-          val export :
-            ?full:bool ->
-            ?depth:int ->
-            ?min:commit list -> ?max:commit list -> t -> slice Lwt.t
-          val import :
-            t -> slice -> (metadata, [ `Msg of branch ]) result Lwt.t
-        end
-      val empty : repo -> t Lwt.t
-      val master : repo -> t Lwt.t
-      val of_branch : repo -> branch -> t Lwt.t
-      val of_commit : commit -> t Lwt.t
-      val repo : t -> repo
-      val tree : t -> tree Lwt.t
-      module Status :
-        sig
-          type t = [ `Branch of branch | `Commit of commit | `Empty ]
-          val t : repo -> t Irmin.Type.ty
-          val pp : t Fmt.t
-        end
-      val status : t -> Status.t
-      module Head :
-        sig
-          val list : repo -> commit list Lwt.t
-          val find : t -> commit option Lwt.t
-          val get : t -> commit Lwt.t
-          val set : t -> commit -> metadata Lwt.t
-          val fast_forward :
-            t ->
-            ?max_depth:int ->
-            ?n:int ->
-            commit ->
-            (metadata,
-             [ `Max_depth_reached | `No_change | `Rejected | `Too_many_lcas ])
-            result Lwt.t
-          val test_and_set :
-            t -> test:commit option -> set:commit option -> bool Lwt.t
-          val merge :
-            into:t ->
-            info:Irmin.Info.f ->
-            ?max_depth:int ->
-            ?n:int -> commit -> (metadata, Irmin.Merge.conflict) result Lwt.t
-        end
-      module Commit :
-        sig
-          type t = commit
-          val t : repo -> t Irmin.Type.ty
-          val pp_hash : t Fmt.t
-          val v :
-            repo -> info:Irmin.Info.t -> parents:t list -> tree -> t Lwt.t
-          val tree : t -> tree Lwt.t
-          val parents : t -> t list Lwt.t
-          val info : t -> Irmin.Info.t
-          module Hash :
-            sig
-              type t = Irmin.Hash.SHA1.t
-              val digest : branch -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = Hash.t
-          val hash : t -> hash
-          val of_hash : repo -> hash -> t option Lwt.t
-        end
-      module Contents :
-        sig
-          type t = contents
-          val t : t Irmin.Type.ty
-          val merge : t option Irmin.Merge.t
-          module Hash :
-            sig
-              type t = Commit.hash
-              val digest : branch -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = Hash.t
-          val hash : repo -> t -> hash Lwt.t
-          val of_hash : repo -> hash -> t option Lwt.t
-        end
-      module Tree :
-        sig
-          val empty : tree
-          val of_contents : ?metadata:metadata -> contents -> tree
-          val of_node : node -> tree
-          val kind : tree -> key -> [ `Contents | `Node ] option Lwt.t
-          val list :
-            tree -> key -> (branch * [ `Contents | `Node ]) list Lwt.t
-          val diff :
-            tree ->
-            tree -> (key * (contents * metadata) Irmin.diff) list Lwt.t
-          val mem : tree -> key -> bool Lwt.t
-          val find_all : tree -> key -> (contents * metadata) option Lwt.t
-          val find : tree -> key -> contents option Lwt.t
-          val get_all : tree -> key -> (contents * metadata) Lwt.t
-          val get : tree -> key -> contents Lwt.t
-          val add :
-            tree -> key -> ?metadata:metadata -> contents -> tree Lwt.t
-          val remove : tree -> key -> tree Lwt.t
-          val mem_tree : tree -> key -> bool Lwt.t
-          val find_tree : tree -> key -> tree option Lwt.t
-          val get_tree : tree -> key -> tree Lwt.t
-          val add_tree : tree -> key -> tree -> tree Lwt.t
-          val merge : tree Irmin.Merge.t
-          val clear_caches : tree -> metadata
-          type marks =
-              Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Tree.marks
-          val empty_marks : metadata -> marks
-          type 'a force = [ `False of key -> 'a -> 'a Lwt.t | `True ]
-          type uniq = [ `False | `Marks of marks | `True ]
-          type 'a node_fn = key -> branch list -> 'a -> 'a Lwt.t
-          val fold :
-            ?force:'a force ->
-            ?uniq:uniq ->
-            ?pre:'a node_fn ->
-            ?post:'a node_fn ->
-            (key -> contents -> 'a -> 'a Lwt.t) -> tree -> 'a -> 'a Lwt.t
-          type stats =
-            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Tree.stats = {
-            nodes : int;
-            leafs : int;
-            skips : int;
-            depth : int;
-            width : int;
-          }
-          val pp_stats : stats Fmt.t
-          val stats : ?force:bool -> tree -> stats Lwt.t
-          type concrete =
-              [ `Contents of contents * metadata
-              | `Tree of (branch * concrete) list ]
-          val of_concrete : concrete -> tree
-          val to_concrete : tree -> concrete Lwt.t
-          module Hash :
-            sig
-              type t = Contents.hash
-              val digest : branch -> t
-              val hash : t -> int
-              val digest_size : int
-              val t : t Irmin.Type.ty
-            end
-          type hash = [ `Contents of Hash.t * metadata | `Node of Hash.t ]
-          val hash_t : hash Irmin.Type.ty
-          val hash : repo -> tree -> hash Lwt.t
-          val of_hash : repo -> hash -> tree option Lwt.t
-        end
-      val kind : t -> key -> [ `Contents | `Node ] option Lwt.t
-      val list : t -> key -> (branch * [ `Contents | `Node ]) list Lwt.t
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .History
+        .E
+        .t
+
+      val compare : t -> t -> int
+
+      type vertex = commit
+
+      val src : t -> vertex
+
+      val dst : t -> vertex
+
+      type label =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .History
+        .E
+        .label
+
+      val create : vertex -> label -> vertex -> t
+
+      val label : t -> label
+    end
+
+    type edge = E.t
+
+    val is_directed : bool
+
+    val is_empty : t -> bool
+
+    val nb_vertex : t -> int
+
+    val nb_edges : t -> int
+
+    val out_degree : t -> vertex -> int
+
+    val in_degree : t -> vertex -> int
+
+    val mem_vertex : t -> vertex -> bool
+
+    val mem_edge : t -> vertex -> vertex -> bool
+
+    val mem_edge_e : t -> edge -> bool
+
+    val find_edge : t -> vertex -> vertex -> edge
+
+    val find_all_edges : t -> vertex -> vertex -> edge list
+
+    val succ : t -> vertex -> vertex list
+
+    val pred : t -> vertex -> vertex list
+
+    val succ_e : t -> vertex -> edge list
+
+    val pred_e : t -> vertex -> edge list
+
+    val iter_vertex : (vertex -> metadata) -> t -> metadata
+
+    val fold_vertex : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val iter_edges : (vertex -> vertex -> metadata) -> t -> metadata
+
+    val fold_edges : (vertex -> vertex -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val iter_edges_e : (edge -> metadata) -> t -> metadata
+
+    val fold_edges_e : (edge -> 'a -> 'a) -> t -> 'a -> 'a
+
+    val map_vertex : (vertex -> vertex) -> t -> t
+
+    val iter_succ : (vertex -> metadata) -> t -> vertex -> metadata
+
+    val iter_pred : (vertex -> metadata) -> t -> vertex -> metadata
+
+    val fold_succ : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val fold_pred : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val iter_succ_e : (edge -> metadata) -> t -> vertex -> metadata
+
+    val fold_succ_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val iter_pred_e : (edge -> metadata) -> t -> vertex -> metadata
+
+    val fold_pred_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
+
+    val empty : t
+
+    val add_vertex : t -> vertex -> t
+
+    val remove_vertex : t -> vertex -> t
+
+    val add_edge : t -> vertex -> vertex -> t
+
+    val add_edge_e : t -> edge -> t
+
+    val remove_edge : t -> vertex -> vertex -> t
+
+    val remove_edge_e : t -> edge -> t
+  end
+
+  val history :
+    ?depth:int -> ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
+
+  module Branch : sig
+    val mem : repo -> branch -> bool Lwt.t
+
+    val find : repo -> branch -> commit option Lwt.t
+
+    val get : repo -> branch -> commit Lwt.t
+
+    val set : repo -> branch -> commit -> metadata Lwt.t
+
+    val remove : repo -> branch -> metadata Lwt.t
+
+    val list : repo -> branch list Lwt.t
+
+    val watch :
+      repo ->
+      branch ->
+      ?init:commit ->
+      (commit Irmin.diff -> metadata Lwt.t) ->
+      watch Lwt.t
+
+    val watch_all :
+      repo ->
+      ?init:(branch * commit) list ->
+      (branch -> commit Irmin.diff -> metadata Lwt.t) ->
+      watch Lwt.t
+
+    type t = branch
+
+    val t : t Irmin.Type.ty
+
+    val master : t
+
+    val is_valid : t -> bool
+  end
+
+  module Key : sig
+    type t = key
+
+    type step = branch
+
+    val empty : t
+
+    val v : step list -> t
+
+    val is_empty : t -> bool
+
+    val cons : step -> t -> t
+
+    val rcons : t -> step -> t
+
+    val decons : t -> (step * t) option
+
+    val rdecons : t -> (t * step) option
+
+    val map : t -> (step -> 'a) -> 'a list
+
+    val t : t Irmin.Type.ty
+
+    val step_t : step Irmin.Type.ty
+  end
+
+  module Metadata : sig
+    type t = metadata
+
+    val t : t Irmin.Type.ty
+
+    val merge : t Irmin.Merge.t
+
+    val default : t
+  end
+
+  val step_t : branch Irmin.Type.ty
+
+  val key_t : key Irmin.Type.ty
+
+  val metadata_t : metadata Irmin.Type.ty
+
+  val contents_t : contents Irmin.Type.ty
+
+  val node_t : node Irmin.Type.ty
+
+  val tree_t : tree Irmin.Type.ty
+
+  val commit_t : repo -> commit Irmin.Type.ty
+
+  val branch_t : branch Irmin.Type.ty
+
+  val slice_t : slice Irmin.Type.ty
+
+  val kind_t : [`Contents | `Node] Irmin.Type.ty
+
+  val lca_error_t : lca_error Irmin.Type.ty
+
+  val ff_error_t : ff_error Irmin.Type.ty
+
+  module Private : sig
+    module Contents : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Contents
+        .t
+
+      type key = Contents.hash
+
+      type value = contents
+
       val mem : t -> key -> bool Lwt.t
-      val mem_tree : t -> key -> bool Lwt.t
-      val find_all : t -> key -> (contents * metadata) option Lwt.t
-      val find : t -> key -> contents option Lwt.t
-      val get_all : t -> key -> (contents * metadata) Lwt.t
-      val get : t -> key -> contents Lwt.t
-      val find_tree : t -> key -> tree option Lwt.t
-      val get_tree : t -> key -> tree Lwt.t
-      type 'a transaction =
-          ?retries:int ->
-          ?allow_empty:bool ->
-          ?strategy:[ `Merge_with_parent of commit | `Set | `Test_and_set ] ->
-          info:Irmin.Info.f -> 'a -> metadata Lwt.t
-      val with_tree :
-        t -> key -> (tree option -> tree option Lwt.t) transaction
-      val set : t -> key -> ?metadata:metadata -> contents transaction
-      val set_tree : t -> key -> tree transaction
-      val remove : t -> key transaction
-      val clone : src:t -> dst:branch -> t Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      val merge : t -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : branch -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Val : sig
+        type t = value
+
+        val t : t Irmin.Type.ty
+
+        val merge : t option Irmin.Merge.t
+      end
+    end
+
+    module Node : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Node
+        .t
+
+      type key = Contents.key
+
+      type value =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Node
+        .value
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      module Path : sig
+        type t = Key.t
+
+        type step = branch
+
+        val empty : t
+
+        val v : step list -> t
+
+        val is_empty : t -> bool
+
+        val cons : step -> t -> t
+
+        val rcons : t -> step -> t
+
+        val decons : t -> (step * t) option
+
+        val rdecons : t -> (t * step) option
+
+        val map : t -> (step -> 'a) -> 'a list
+
+        val t : t Irmin.Type.ty
+
+        val step_t : step Irmin.Type.ty
+      end
+
+      val merge : t -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : branch -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Metadata : sig
+        type t = metadata
+
+        val t : t Irmin.Type.ty
+
+        val merge : t Irmin.Merge.t
+
+        val default : t
+      end
+
+      module Val : sig
+        type t = value
+
+        type metadata = unit
+
+        type contents = key
+
+        type node = contents
+
+        type step = branch
+
+        type value =
+          [ `Contents of node * metadata
+          | `Node of node ]
+
+        val v : (step * value) list -> t
+
+        val list : t -> (step * value) list
+
+        val empty : t
+
+        val is_empty : t -> bool
+
+        val find : t -> step -> value option
+
+        val update : t -> step -> value -> t
+
+        val remove : t -> step -> t
+
+        val t : t Irmin.Type.ty
+
+        val metadata_t : metadata Irmin.Type.ty
+
+        val contents_t : node Irmin.Type.ty
+
+        val node_t : node Irmin.Type.ty
+
+        val step_t : step Irmin.Type.ty
+
+        val value_t : value Irmin.Type.ty
+      end
+
+      module Contents : sig
+        type t =
+          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+            (Irmin.Branch.String)
+            (Irmin.Hash.SHA1)
+          .Private
+          .Node
+          .Contents
+          .t
+
+        type key = Val.node
+
+        type value =
+          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+            (Irmin.Branch.String)
+            (Irmin.Hash.SHA1)
+          .Private
+          .Node
+          .Contents
+          .value
+
+        val mem : t -> key -> bool Lwt.t
+
+        val find : t -> key -> value option Lwt.t
+
+        val add : t -> value -> key Lwt.t
+
+        val merge : t -> key option Irmin.Merge.t
+
+        module Key : sig
+          type t = key
+
+          val digest : branch -> t
+
+          val hash : t -> int
+
+          val digest_size : int
+
+          val t : t Irmin.Type.ty
+        end
+
+        module Val : sig
+          type t = value
+
+          val t : t Irmin.Type.ty
+
+          val merge : t option Irmin.Merge.t
+        end
+      end
+    end
+
+    module Commit : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Commit
+        .t
+
+      type key = Node.key
+
+      type value =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Commit
+        .value
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val add : t -> value -> key Lwt.t
+
+      val merge : t -> info:Irmin.Info.f -> key option Irmin.Merge.t
+
+      module Key : sig
+        type t = key
+
+        val digest : branch -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
+
+      module Val : sig
+        type t = value
+
+        type commit = key
+
+        type node = commit
+
+        val v : info:Irmin.Info.t -> node:node -> parents:node list -> t
+
+        val node : t -> node
+
+        val parents : t -> node list
+
+        val info : t -> Irmin.Info.t
+
+        val t : t Irmin.Type.ty
+
+        val commit_t : node Irmin.Type.ty
+
+        val node_t : node Irmin.Type.ty
+      end
+
+      module Node : sig
+        type t =
+          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+            (Irmin.Branch.String)
+            (Irmin.Hash.SHA1)
+          .Private
+          .Commit
+          .Node
+          .t
+
+        type key = Val.node
+
+        type value =
+          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+            (Irmin.Branch.String)
+            (Irmin.Hash.SHA1)
+          .Private
+          .Commit
+          .Node
+          .value
+
+        val mem : t -> key -> bool Lwt.t
+
+        val find : t -> key -> value option Lwt.t
+
+        val add : t -> value -> key Lwt.t
+
+        module Path : sig
+          type t =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Path
+            .t
+
+          type step =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Path
+            .step
+
+          val empty : t
+
+          val v : step list -> t
+
+          val is_empty : t -> bool
+
+          val cons : step -> t -> t
+
+          val rcons : t -> step -> t
+
+          val decons : t -> (step * t) option
+
+          val rdecons : t -> (t * step) option
+
+          val map : t -> (step -> 'a) -> 'a list
+
+          val t : t Irmin.Type.ty
+
+          val step_t : step Irmin.Type.ty
+        end
+
+        val merge : t -> key option Irmin.Merge.t
+
+        module Key : sig
+          type t = key
+
+          val digest : branch -> t
+
+          val hash : t -> int
+
+          val digest_size : int
+
+          val t : t Irmin.Type.ty
+        end
+
+        module Metadata : sig
+          type t =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Metadata
+            .t
+
+          val t : t Irmin.Type.ty
+
+          val merge : t Irmin.Merge.t
+
+          val default : t
+        end
+
+        module Val : sig
+          type t = value
+
+          type metadata = Metadata.t
+
+          type contents =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Val
+            .contents
+
+          type node = key
+
+          type step = Path.step
+
+          type value =
+            [ `Contents of contents * metadata
+            | `Node of node ]
+
+          val v : (step * value) list -> t
+
+          val list : t -> (step * value) list
+
+          val empty : t
+
+          val is_empty : t -> bool
+
+          val find : t -> step -> value option
+
+          val update : t -> step -> value -> t
+
+          val remove : t -> step -> t
+
+          val t : t Irmin.Type.ty
+
+          val metadata_t : metadata Irmin.Type.ty
+
+          val contents_t : contents Irmin.Type.ty
+
+          val node_t : node Irmin.Type.ty
+
+          val step_t : step Irmin.Type.ty
+
+          val value_t : value Irmin.Type.ty
+        end
+
+        module Contents : sig
+          type t =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Contents
+            .t
+
+          type key = Val.contents
+
+          type value =
+            Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+              (Irmin.Branch.String)
+              (Irmin.Hash.SHA1)
+            .Private
+            .Commit
+            .Node
+            .Contents
+            .value
+
+          val mem : t -> key -> bool Lwt.t
+
+          val find : t -> key -> value option Lwt.t
+
+          val add : t -> value -> key Lwt.t
+
+          val merge : t -> key option Irmin.Merge.t
+
+          module Key : sig
+            type t = key
+
+            val digest : branch -> t
+
+            val hash : t -> int
+
+            val digest_size : int
+
+            val t : t Irmin.Type.ty
+          end
+
+          module Val : sig
+            type t = value
+
+            val t : t Irmin.Type.ty
+
+            val merge : t option Irmin.Merge.t
+          end
+        end
+      end
+    end
+
+    module Branch : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Branch
+        .t
+
+      type key = branch
+
+      type value = Commit.key
+
+      val mem : t -> key -> bool Lwt.t
+
+      val find : t -> key -> value option Lwt.t
+
+      val set : t -> key -> value -> metadata Lwt.t
+
+      val test_and_set :
+        t -> key -> test:value option -> set:value option -> bool Lwt.t
+
+      val remove : t -> key -> metadata Lwt.t
+
       type watch =
-          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).watch
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Branch
+        .watch
+
       val watch :
         t ->
-        ?init:commit -> (commit Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
+        ?init:(key * value) list ->
+        (key -> value Irmin.diff -> metadata Lwt.t) ->
+        watch Lwt.t
+
       val watch_key :
         t ->
         key ->
-        ?init:commit ->
-        ((commit * tree) Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-      val unwatch : watch -> metadata Lwt.t
-      type 'a merge =
-          info:Irmin.Info.f ->
-          ?max_depth:int ->
-          ?n:int -> 'a -> (metadata, Irmin.Merge.conflict) result Lwt.t
-      val merge : into:t -> t merge
-      val merge_with_branch : t -> branch merge
-      val merge_with_commit : t -> commit merge
-      val lcas :
-        ?max_depth:int ->
-        ?n:int -> t -> t -> (commit list, lca_error) result Lwt.t
-      val lcas_with_branch :
-        t ->
-        ?max_depth:int ->
-        ?n:int -> branch -> (commit list, lca_error) result Lwt.t
-      val lcas_with_commit :
-        t ->
-        ?max_depth:int ->
-        ?n:int -> commit -> (commit list, lca_error) result Lwt.t
-      module History :
-        sig
-          type t =
-              Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).History.t
-          module V :
-            sig
-              type t = commit
-              val compare : t -> t -> int
-              val hash : t -> int
-              val equal : t -> t -> bool
-              type label =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).History.V.label
-              val create : label -> t
-              val label : t -> label
-            end
-          type vertex = commit
-          module E :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).History.E.t
-              val compare : t -> t -> int
-              type vertex = commit
-              val src : t -> vertex
-              val dst : t -> vertex
-              type label =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).History.E.label
-              val create : vertex -> label -> vertex -> t
-              val label : t -> label
-            end
-          type edge = E.t
-          val is_directed : bool
-          val is_empty : t -> bool
-          val nb_vertex : t -> int
-          val nb_edges : t -> int
-          val out_degree : t -> vertex -> int
-          val in_degree : t -> vertex -> int
-          val mem_vertex : t -> vertex -> bool
-          val mem_edge : t -> vertex -> vertex -> bool
-          val mem_edge_e : t -> edge -> bool
-          val find_edge : t -> vertex -> vertex -> edge
-          val find_all_edges : t -> vertex -> vertex -> edge list
-          val succ : t -> vertex -> vertex list
-          val pred : t -> vertex -> vertex list
-          val succ_e : t -> vertex -> edge list
-          val pred_e : t -> vertex -> edge list
-          val iter_vertex : (vertex -> metadata) -> t -> metadata
-          val fold_vertex : (vertex -> 'a -> 'a) -> t -> 'a -> 'a
-          val iter_edges : (vertex -> vertex -> metadata) -> t -> metadata
-          val fold_edges : (vertex -> vertex -> 'a -> 'a) -> t -> 'a -> 'a
-          val iter_edges_e : (edge -> metadata) -> t -> metadata
-          val fold_edges_e : (edge -> 'a -> 'a) -> t -> 'a -> 'a
-          val map_vertex : (vertex -> vertex) -> t -> t
-          val iter_succ : (vertex -> metadata) -> t -> vertex -> metadata
-          val iter_pred : (vertex -> metadata) -> t -> vertex -> metadata
-          val fold_succ : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val fold_pred : (vertex -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val iter_succ_e : (edge -> metadata) -> t -> vertex -> metadata
-          val fold_succ_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val iter_pred_e : (edge -> metadata) -> t -> vertex -> metadata
-          val fold_pred_e : (edge -> 'a -> 'a) -> t -> vertex -> 'a -> 'a
-          val empty : t
-          val add_vertex : t -> vertex -> t
-          val remove_vertex : t -> vertex -> t
-          val add_edge : t -> vertex -> vertex -> t
-          val add_edge_e : t -> edge -> t
-          val remove_edge : t -> vertex -> vertex -> t
-          val remove_edge_e : t -> edge -> t
-        end
-      val history :
-        ?depth:int ->
-        ?min:commit list -> ?max:commit list -> t -> History.t Lwt.t
-      module Branch :
-        sig
-          val mem : repo -> branch -> bool Lwt.t
-          val find : repo -> branch -> commit option Lwt.t
-          val get : repo -> branch -> commit Lwt.t
-          val set : repo -> branch -> commit -> metadata Lwt.t
-          val remove : repo -> branch -> metadata Lwt.t
-          val list : repo -> branch list Lwt.t
-          val watch :
-            repo ->
-            branch ->
-            ?init:commit ->
-            (commit Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-          val watch_all :
-            repo ->
-            ?init:(branch * commit) list ->
-            (branch -> commit Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-          type t = branch
-          val t : t Irmin.Type.ty
-          val master : t
-          val is_valid : t -> bool
-        end
-      module Key :
-        sig
-          type t = key
-          type step = branch
-          val empty : t
-          val v : step list -> t
-          val is_empty : t -> bool
-          val cons : step -> t -> t
-          val rcons : t -> step -> t
-          val decons : t -> (step * t) option
-          val rdecons : t -> (t * step) option
-          val map : t -> (step -> 'a) -> 'a list
-          val t : t Irmin.Type.ty
-          val step_t : step Irmin.Type.ty
-        end
-      module Metadata :
-        sig
-          type t = metadata
-          val t : t Irmin.Type.ty
-          val merge : t Irmin.Merge.t
-          val default : t
-        end
-      val step_t : branch Irmin.Type.ty
-      val key_t : key Irmin.Type.ty
-      val metadata_t : metadata Irmin.Type.ty
-      val contents_t : contents Irmin.Type.ty
-      val node_t : node Irmin.Type.ty
-      val tree_t : tree Irmin.Type.ty
-      val commit_t : repo -> commit Irmin.Type.ty
-      val branch_t : branch Irmin.Type.ty
-      val slice_t : slice Irmin.Type.ty
-      val kind_t : [ `Contents | `Node ] Irmin.Type.ty
-      val lca_error_t : lca_error Irmin.Type.ty
-      val ff_error_t : ff_error Irmin.Type.ty
-      module Private :
-        sig
-          module Contents :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Contents.t
-              type key = Contents.hash
-              type value = contents
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              val merge : t -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : branch -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Val :
-                sig
-                  type t = value
-                  val t : t Irmin.Type.ty
-                  val merge : t option Irmin.Merge.t
-                end
-            end
-          module Node :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Node.t
-              type key = Contents.key
-              type value =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Node.value
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              module Path :
-                sig
-                  type t = Key.t
-                  type step = branch
-                  val empty : t
-                  val v : step list -> t
-                  val is_empty : t -> bool
-                  val cons : step -> t -> t
-                  val rcons : t -> step -> t
-                  val decons : t -> (step * t) option
-                  val rdecons : t -> (t * step) option
-                  val map : t -> (step -> 'a) -> 'a list
-                  val t : t Irmin.Type.ty
-                  val step_t : step Irmin.Type.ty
-                end
-              val merge : t -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : branch -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Metadata :
-                sig
-                  type t = metadata
-                  val t : t Irmin.Type.ty
-                  val merge : t Irmin.Merge.t
-                  val default : t
-                end
-              module Val :
-                sig
-                  type t = value
-                  type metadata = unit
-                  type contents = key
-                  type node = contents
-                  type step = branch
-                  type value =
-                      [ `Contents of node * metadata | `Node of node ]
-                  val v : (step * value) list -> t
-                  val list : t -> (step * value) list
-                  val empty : t
-                  val is_empty : t -> bool
-                  val find : t -> step -> value option
-                  val update : t -> step -> value -> t
-                  val remove : t -> step -> t
-                  val t : t Irmin.Type.ty
-                  val metadata_t : metadata Irmin.Type.ty
-                  val contents_t : node Irmin.Type.ty
-                  val node_t : node Irmin.Type.ty
-                  val step_t : step Irmin.Type.ty
-                  val value_t : value Irmin.Type.ty
-                end
-              module Contents :
-                sig
-                  type t =
-                      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Node.Contents.t
-                  type key = Val.node
-                  type value =
-                      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Node.Contents.value
-                  val mem : t -> key -> bool Lwt.t
-                  val find : t -> key -> value option Lwt.t
-                  val add : t -> value -> key Lwt.t
-                  val merge : t -> key option Irmin.Merge.t
-                  module Key :
-                    sig
-                      type t = key
-                      val digest : branch -> t
-                      val hash : t -> int
-                      val digest_size : int
-                      val t : t Irmin.Type.ty
-                    end
-                  module Val :
-                    sig
-                      type t = value
-                      val t : t Irmin.Type.ty
-                      val merge : t option Irmin.Merge.t
-                    end
-                end
-            end
-          module Commit :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.t
-              type key = Node.key
-              type value =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.value
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val add : t -> value -> key Lwt.t
-              val merge : t -> info:Irmin.Info.f -> key option Irmin.Merge.t
-              module Key :
-                sig
-                  type t = key
-                  val digest : branch -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-              module Val :
-                sig
-                  type t = value
-                  type commit = key
-                  type node = commit
-                  val v :
-                    info:Irmin.Info.t -> node:node -> parents:node list -> t
-                  val node : t -> node
-                  val parents : t -> node list
-                  val info : t -> Irmin.Info.t
-                  val t : t Irmin.Type.ty
-                  val commit_t : node Irmin.Type.ty
-                  val node_t : node Irmin.Type.ty
-                end
-              module Node :
-                sig
-                  type t =
-                      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.t
-                  type key = Val.node
-                  type value =
-                      Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.value
-                  val mem : t -> key -> bool Lwt.t
-                  val find : t -> key -> value option Lwt.t
-                  val add : t -> value -> key Lwt.t
-                  module Path :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Path.t
-                      type step =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Path.step
-                      val empty : t
-                      val v : step list -> t
-                      val is_empty : t -> bool
-                      val cons : step -> t -> t
-                      val rcons : t -> step -> t
-                      val decons : t -> (step * t) option
-                      val rdecons : t -> (t * step) option
-                      val map : t -> (step -> 'a) -> 'a list
-                      val t : t Irmin.Type.ty
-                      val step_t : step Irmin.Type.ty
-                    end
-                  val merge : t -> key option Irmin.Merge.t
-                  module Key :
-                    sig
-                      type t = key
-                      val digest : branch -> t
-                      val hash : t -> int
-                      val digest_size : int
-                      val t : t Irmin.Type.ty
-                    end
-                  module Metadata :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Metadata.t
-                      val t : t Irmin.Type.ty
-                      val merge : t Irmin.Merge.t
-                      val default : t
-                    end
-                  module Val :
-                    sig
-                      type t = value
-                      type metadata = Metadata.t
-                      type contents =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Val.contents
-                      type node = key
-                      type step = Path.step
-                      type value =
-                          [ `Contents of contents * metadata | `Node of node ]
-                      val v : (step * value) list -> t
-                      val list : t -> (step * value) list
-                      val empty : t
-                      val is_empty : t -> bool
-                      val find : t -> step -> value option
-                      val update : t -> step -> value -> t
-                      val remove : t -> step -> t
-                      val t : t Irmin.Type.ty
-                      val metadata_t : metadata Irmin.Type.ty
-                      val contents_t : contents Irmin.Type.ty
-                      val node_t : node Irmin.Type.ty
-                      val step_t : step Irmin.Type.ty
-                      val value_t : value Irmin.Type.ty
-                    end
-                  module Contents :
-                    sig
-                      type t =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Contents.t
-                      type key = Val.contents
-                      type value =
-                          Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Commit.Node.Contents.value
-                      val mem : t -> key -> bool Lwt.t
-                      val find : t -> key -> value option Lwt.t
-                      val add : t -> value -> key Lwt.t
-                      val merge : t -> key option Irmin.Merge.t
-                      module Key :
-                        sig
-                          type t = key
-                          val digest : branch -> t
-                          val hash : t -> int
-                          val digest_size : int
-                          val t : t Irmin.Type.ty
-                        end
-                      module Val :
-                        sig
-                          type t = value
-                          val t : t Irmin.Type.ty
-                          val merge : t option Irmin.Merge.t
-                        end
-                    end
-                end
-            end
-          module Branch :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Branch.t
-              type key = branch
-              type value = Commit.key
-              val mem : t -> key -> bool Lwt.t
-              val find : t -> key -> value option Lwt.t
-              val set : t -> key -> value -> metadata Lwt.t
-              val test_and_set :
-                t ->
-                key -> test:value option -> set:value option -> bool Lwt.t
-              val remove : t -> key -> metadata Lwt.t
-              type watch =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Branch.watch
-              val watch :
-                t ->
-                ?init:(key * value) list ->
-                (key -> value Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-              val watch_key :
-                t ->
-                key ->
-                ?init:value ->
-                (value Irmin.diff -> metadata Lwt.t) -> watch Lwt.t
-              val unwatch : t -> watch -> metadata Lwt.t
-              val list : t -> key list Lwt.t
-              module Key :
-                sig
-                  type t = key
-                  val t : t Irmin.Type.ty
-                  val master : t
-                  val is_valid : t -> bool
-                end
-              module Val :
-                sig
-                  type t = value
-                  val digest : key -> t
-                  val hash : t -> int
-                  val digest_size : int
-                  val t : t Irmin.Type.ty
-                end
-            end
-          module Slice :
-            sig
-              type t = slice
-              type contents = Branch.value * Contents.value
-              type node = Branch.value * Node.value
-              type commit = Branch.value * Commit.value
-              type value =
-                  [ `Commit of commit | `Contents of contents | `Node of node ]
-              val empty : metadata -> t Lwt.t
-              val add : t -> value -> metadata Lwt.t
-              val iter : t -> (value -> metadata Lwt.t) -> metadata Lwt.t
-              val t : t Irmin.Type.ty
-              val contents_t : contents Irmin.Type.ty
-              val node_t : node Irmin.Type.ty
-              val commit_t : commit Irmin.Type.ty
-              val value_t : value Irmin.Type.ty
-            end
-          module Repo :
-            sig
-              type t = repo
-              val v : Irmin.config -> t Lwt.t
-              val contents_t : t -> Contents.t
-              val node_t : t -> Node.t
-              val commit_t : t -> Commit.t
-              val branch_t : t -> Branch.t
-            end
-          module Sync :
-            sig
-              type t =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Sync.t
-              type commit = Branch.value
-              type branch = step
-              type endpoint =
-                  Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA1).Private.Sync.endpoint
-              val fetch :
-                t ->
-                ?depth:int ->
-                endpoint ->
-                branch ->
-                (commit, [ `Msg of branch | `No_head | `Not_available ])
-                result Lwt.t
-              val push :
-                t ->
-                ?depth:int ->
-                endpoint ->
-                branch ->
-                (metadata,
-                 [ `Detached_head
-                 | `Msg of branch
-                 | `No_head
-                 | `Not_available ])
-                result Lwt.t
-              val v : repo -> t Lwt.t
-            end
-        end
-      type Irmin.remote += E of Private.Sync.endpoint
-      val flush : DB.t -> int64 Lwt.t
+        ?init:value ->
+        (value Irmin.diff -> metadata Lwt.t) ->
+        watch Lwt.t
+
+      val unwatch : t -> watch -> metadata Lwt.t
+
+      val list : t -> key list Lwt.t
+
+      module Key : sig
+        type t = key
+
+        val t : t Irmin.Type.ty
+
+        val master : t
+
+        val is_valid : t -> bool
+      end
+
+      module Val : sig
+        type t = value
+
+        val digest : key -> t
+
+        val hash : t -> int
+
+        val digest_size : int
+
+        val t : t Irmin.Type.ty
+      end
     end
+
+    module Slice : sig
+      type t = slice
+
+      type contents = Branch.value * Contents.value
+
+      type node = Branch.value * Node.value
+
+      type commit = Branch.value * Commit.value
+
+      type value =
+        [ `Commit of commit
+        | `Contents of contents
+        | `Node of node ]
+
+      val empty : metadata -> t Lwt.t
+
+      val add : t -> value -> metadata Lwt.t
+
+      val iter : t -> (value -> metadata Lwt.t) -> metadata Lwt.t
+
+      val t : t Irmin.Type.ty
+
+      val contents_t : contents Irmin.Type.ty
+
+      val node_t : node Irmin.Type.ty
+
+      val commit_t : commit Irmin.Type.ty
+
+      val value_t : value Irmin.Type.ty
+    end
+
+    module Repo : sig
+      type t = repo
+
+      val v : Irmin.config -> t Lwt.t
+
+      val contents_t : t -> Contents.t
+
+      val node_t : t -> Node.t
+
+      val commit_t : t -> Commit.t
+
+      val branch_t : t -> Branch.t
+    end
+
+    module Sync : sig
+      type t =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Sync
+        .t
+
+      type commit = Branch.value
+
+      type branch = step
+
+      type endpoint =
+        Irmin.Make(AO)(RW)(Irmin.Metadata.None)(C)(Irmin.Path.String_list)
+          (Irmin.Branch.String)
+          (Irmin.Hash.SHA1)
+        .Private
+        .Sync
+        .endpoint
+
+      val fetch :
+        t ->
+        ?depth:int ->
+        endpoint ->
+        branch ->
+        (commit, [`Msg of branch | `No_head | `Not_available]) result Lwt.t
+
+      val push :
+        t ->
+        ?depth:int ->
+        endpoint ->
+        branch ->
+        ( metadata,
+          [`Detached_head | `Msg of branch | `No_head | `Not_available] )
+        result
+        Lwt.t
+
+      val v : repo -> t Lwt.t
+    end
+  end
+
+  type Irmin.remote += E of Private.Sync.endpoint
+
+  val flush : DB.t -> int64 Lwt.t
+end

--- a/src/wodan-unix/unikernel.ml
+++ b/src/wodan-unix/unikernel.ml
@@ -1,142 +1,210 @@
-(*************************************************************************************)
-(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                          *)
-(*                                                                                   *)
-(*  Permission to use, copy, modify, and/or distribute this software for any         *)
-(*  purpose with or without fee is hereby granted, provided that the above           *)
-(*  copyright notice and this permission notice appear in all copies.                *)
-(*                                                                                   *)
-(*  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH    *)
-(*  REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND  *)
-(*  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,         *)
-(*  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM      *)
-(*  LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR    *)
-(*  OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR           *)
-(*  PERFORMANCE OF THIS SOFTWARE.                                                    *)
-(*                                                                                   *)
-(*************************************************************************************)
+(******************************************************************************)
+(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                   *)
+(*                                                                            *)
+(* Permission to use, copy, modify, and/or distribute this software for any   *)
+(* purpose with or without fee is hereby granted, provided that the above     *)
+(* copyright notice and this permission notice appear in all copies.          *)
+(*                                                                            *)
+(* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES   *)
+(* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF           *)
+(* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR    *)
+(* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES     *)
+(* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN      *)
+(* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR *)
+(* IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.                *)
+(*                                                                            *)
+(******************************************************************************)
 
 open Lwt.Infix
 open Mirage_block
 
 let unwrap_opt = function
-|None -> failwith "Expected Some"
-|Some x -> x
+  | None ->
+      failwith "Expected Some"
+  | Some x ->
+      x
 
-module Client (B: Wodan.EXTBLOCK) = struct
+module Client (B : Wodan.EXTBLOCK) = struct
   let trim disk =
     Wodan.open_for_reading (module B) disk Wodan.standard_mount_options
-    >>= function (Wodan.OPEN_RET ((module Stor), root, _gen)) ->
-    Stor.fstrim root
+    >>= function
+    | Wodan.OPEN_RET ((module Stor), root, _gen) ->
+        Stor.fstrim root
 
   let format disk ks bs =
-    let module Stor = Wodan.Make(B)(struct
-        include Wodan.StandardSuperblockParams
-        let key_size = ks
-        let block_size = bs
-      end) in
+    let module Stor =
+      Wodan.Make
+        (B)
+        (struct
+          include Wodan.StandardSuperblockParams
+
+          let key_size = ks
+
+          let block_size = bs
+        end)
+    in
     let%lwt info = B.get_info disk in
-    let%lwt _root, _gen = Stor.prepare_io (Wodan.FormatEmptyDevice
-      Int64.(div (mul info.size_sectors @@ of_int info.sector_size) @@ of_int Wodan.StandardSuperblockParams.block_size)) disk Wodan.standard_mount_options in
+    let%lwt _root, _gen =
+      Stor.prepare_io
+        (Wodan.FormatEmptyDevice
+           Int64.(
+             div (mul info.size_sectors @@ of_int info.sector_size)
+             @@ of_int Wodan.StandardSuperblockParams.block_size))
+        disk Wodan.standard_mount_options
+    in
     Lwt.return_unit
 
   let restore disk =
     Wodan.open_for_reading (module B) disk Wodan.standard_mount_options
-    >>= function (Wodan.OPEN_RET ((module Stor), root, _gen)) ->
-    let csv_in = Csv.of_channel ~separator:'\t' stdin in
-    let compl = ref [] in
-    Csv.iter ~f:(fun l ->
-      match l with
-      |[k; v] ->
-      compl := ( try%lwt Stor.insert root (Stor.key_of_string @@ B64.decode k) (Stor.value_of_string @@ B64.decode v) with Wodan.NeedsFlush -> let%lwt _gen = Stor.flush root in Lwt.return_unit ) :: !compl
-      |_ -> failwith "Bad CSV format"
-      ) csv_in;
-    Lwt.join !compl >>= fun () ->
-    let%lwt _gen = Stor.flush root in
-    Lwt.return_unit
+    >>= function
+    | Wodan.OPEN_RET ((module Stor), root, _gen) ->
+        let csv_in = Csv.of_channel ~separator:'\t' stdin in
+        let compl = ref [] in
+        Csv.iter
+          ~f:(fun l ->
+            match l with
+            | [k; v] ->
+                compl :=
+                  ( try%lwt
+                          Stor.insert root
+                            (Stor.key_of_string @@ B64.decode k)
+                            (Stor.value_of_string @@ B64.decode v)
+                    with Wodan.NeedsFlush ->
+                      let%lwt _gen = Stor.flush root in
+                      Lwt.return_unit )
+                  :: !compl
+            | _ ->
+                failwith "Bad CSV format" )
+          csv_in;
+        Lwt.join !compl
+        >>= fun () ->
+        let%lwt _gen = Stor.flush root in
+        Lwt.return_unit
 
   let dump disk =
     Wodan.open_for_reading (module B) disk Wodan.standard_mount_options
-    >>= function (Wodan.OPEN_RET ((module Stor), root, _gen)) ->
-    let out_csv = Csv.to_channel ~separator:'\t' stdout in
-    Stor.iter root (fun k v ->
-      Csv.output_record out_csv [B64.encode @@ Stor.string_of_key k; B64.encode @@ Stor.string_of_value v]) >>= fun () ->
-    begin Csv.close_out out_csv;
-    Lwt.return_unit end
+    >>= function
+    | Wodan.OPEN_RET ((module Stor), root, _gen) ->
+        let out_csv = Csv.to_channel ~separator:'\t' stdout in
+        Stor.iter root (fun k v ->
+            Csv.output_record out_csv
+              [ B64.encode @@ Stor.string_of_key k;
+                B64.encode @@ Stor.string_of_value v ] )
+        >>= fun () -> Csv.close_out out_csv; Lwt.return_unit
 
   let exercise disk block_size =
-    let bs = match block_size with
-      |None -> Wodan.StandardSuperblockParams.block_size
-      |Some block_size -> block_size
+    let bs =
+      match block_size with
+      | None ->
+          Wodan.StandardSuperblockParams.block_size
+      | Some block_size ->
+          block_size
     in
-    let module Stor = Wodan.Make(B)(struct
-        include Wodan.StandardSuperblockParams
-        let block_size = bs
-      end) in
+    let module Stor =
+      Wodan.Make
+        (B)
+        (struct
+          include Wodan.StandardSuperblockParams
 
+          let block_size = bs
+        end)
+    in
     let ios = ref 0 in
     let time0 = ref 0. in
     let%lwt info = B.get_info disk in
     (*Logs.info (fun m ->
         m "Sectors %Ld %d" info.size_sectors info.sector_size);*)
-    let%lwt rootval, _gen0 = Stor.prepare_io (Wodan.FormatEmptyDevice
-      Int64.(div (mul info.size_sectors @@ of_int info.sector_size) @@ of_int Stor.P.block_size)) disk Wodan.standard_mount_options in
-    (
-    let root = ref rootval in
-    let key = Stor.key_of_string "abcdefghijklmnopqrst" in
-    let cval = Stor.value_of_string "sqnlnfdvulnqsvfjlllsvqoiuuoezr" in
-    Stor.insert !root key cval >>= fun () ->
-    Stor.flush !root >>= function gen1 ->
-    Stor.lookup !root key >>= function cval1_opt ->
-    let cval1 = unwrap_opt cval1_opt in
-    (*Cstruct.hexdump cval1;*)
-    assert (Cstruct.equal (Stor.cstruct_of_value cval) (Stor.cstruct_of_value cval1));
-    let%lwt rootval, gen2 = Stor.prepare_io Wodan.OpenExistingDevice disk Wodan.standard_mount_options in
-    root := rootval;
-    Stor.lookup !root key >>= function cval2_opt ->
-    let cval2 = unwrap_opt cval2_opt in
-    assert (Cstruct.equal (Stor.cstruct_of_value cval) (Stor.cstruct_of_value cval2));
-    if gen1 <> gen2 then begin Logs.err (fun m -> m "Generation fail %Ld %Ld" gen1 gen2); assert false; end;
-    time0 := Unix.gettimeofday ();
-    let should_continue = ref true in
-    while%lwt !should_continue do
-      let key = Stor.key_of_cstruct @@ Nocrypto.Rng.generate 20 and
-        cval = Stor.value_of_cstruct @@ Nocrypto.Rng.generate 40 in
-      begin try%lwt
-        ios := succ !ios;
-        Stor.insert !root key cval
-      with
-      |Wodan.NeedsFlush -> begin
-        Logs.info (fun m -> m "Emergency flushing");
-        Stor.flush !root >>= function _gen ->
-        Stor.insert !root key cval
-      end
-      |Wodan.OutOfSpace -> begin
-        Logs.info (fun m -> m "Final flush");
-        Stor.flush !root >|= ignore >>= fun () ->
-        should_continue := false;
-        Lwt.return_unit
-      end
-      end
-      >>= fun () ->
-      if%lwt Lwt.return (Nocrypto.Rng.Int.gen 16384 = 0) then begin (* Infrequent re-opening *)
-        Stor.flush !root >>= function gen3 ->
-        let%lwt rootval, gen4 = Stor.prepare_io Wodan.OpenExistingDevice disk Wodan.standard_mount_options in
-        root := rootval;
-        assert (gen3 = gen4);
-        Lwt.return ()
-      end
-      else if%lwt Lwt.return (false && Nocrypto.Rng.Int.gen 8192 = 0) then begin (* Infrequent flushing *)
-        Stor.log_statistics !root;
-        Stor.flush !root >|= ignore
-      end done
-      )
-      [%lwt.finally begin
+    let%lwt rootval, _gen0 =
+      Stor.prepare_io
+        (Wodan.FormatEmptyDevice
+           Int64.(
+             div (mul info.size_sectors @@ of_int info.sector_size)
+             @@ of_int Stor.P.block_size))
+        disk Wodan.standard_mount_options
+    in
+    (let root = ref rootval in
+     let key = Stor.key_of_string "abcdefghijklmnopqrst" in
+     let cval = Stor.value_of_string "sqnlnfdvulnqsvfjlllsvqoiuuoezr" in
+     Stor.insert !root key cval
+     >>= fun () ->
+     Stor.flush !root
+     >>= function
+     | gen1 -> (
+         Stor.lookup !root key
+         >>= function
+         | cval1_opt -> (
+             let cval1 = unwrap_opt cval1_opt in
+             (*Cstruct.hexdump cval1;*)
+             assert (
+               Cstruct.equal
+                 (Stor.cstruct_of_value cval)
+                 (Stor.cstruct_of_value cval1) );
+             let%lwt rootval, gen2 =
+               Stor.prepare_io Wodan.OpenExistingDevice disk
+                 Wodan.standard_mount_options
+             in
+             root := rootval;
+             Stor.lookup !root key
+             >>= function
+             | cval2_opt ->
+                 let cval2 = unwrap_opt cval2_opt in
+                 assert (
+                   Cstruct.equal
+                     (Stor.cstruct_of_value cval)
+                     (Stor.cstruct_of_value cval2) );
+                 if gen1 <> gen2 then (
+                   Logs.err (fun m -> m "Generation fail %Ld %Ld" gen1 gen2);
+                   assert false );
+                 time0 := Unix.gettimeofday ();
+                 let should_continue = ref true in
+                 while%lwt !should_continue do
+                   let key = Stor.key_of_cstruct @@ Nocrypto.Rng.generate 20
+                   and cval =
+                     Stor.value_of_cstruct @@ Nocrypto.Rng.generate 40
+                   in
+                   ( try%lwt
+                       ios := succ !ios;
+                       Stor.insert !root key cval
+                     with
+                   | Wodan.NeedsFlush -> (
+                       Logs.info (fun m -> m "Emergency flushing");
+                       Stor.flush !root
+                       >>= function
+                       | _gen ->
+                           Stor.insert !root key cval )
+                   | Wodan.OutOfSpace ->
+                       Logs.info (fun m -> m "Final flush");
+                       Stor.flush !root
+                       >|= ignore
+                       >>= fun () ->
+                       should_continue := false;
+                       Lwt.return_unit )
+                   >>= fun () ->
+                   if%lwt Lwt.return (Nocrypto.Rng.Int.gen 16384 = 0) then (
+                     (* Infrequent re-opening *)
+                       Stor.flush !root
+                     >>= function
+                     | gen3 ->
+                         let%lwt rootval, gen4 =
+                           Stor.prepare_io Wodan.OpenExistingDevice disk
+                             Wodan.standard_mount_options
+                         in
+                         root := rootval;
+                         assert (gen3 = gen4);
+                         Lwt.return () )
+                   else
+                     if%lwt Lwt.return (false && Nocrypto.Rng.Int.gen 8192 = 0)
+                     then (
+                       (* Infrequent flushing *)
+                       Stor.log_statistics !root;
+                       Stor.flush !root >|= ignore )
+                 done ) ))
+      [%lwt.finally
         let time1 = Unix.gettimeofday () in
-        let iops = (float_of_int !ios) /. (time1 -. !time0) in
+        let iops = float_of_int !ios /. (time1 -. !time0) in
         (*Stor.log_statistics root;*)
         Logs.info (fun m -> m "IOPS %f" iops);
-        Lwt.return_unit
-      end]
+        Lwt.return_unit]
 
   let bench0 count =
     (* Ignore original disk, build a ramdisk instead *)
@@ -146,97 +214,131 @@ module Client (B: Wodan.EXTBLOCK) = struct
     (*let module Ramdisk = Wodan.BlockCompat(Ramdisk) in*)
     let module Ramdisk = struct
       include Ramdisk
+
       let discard _ _ _ = Lwt.return @@ Ok ()
     end in
-    let module Stor = Wodan.Make(Ramdisk)(struct
-        include Wodan.StandardSuperblockParams
-        let key_size = 20
-        let block_size = 256*1024
-      end) in
+    let module Stor =
+      Wodan.Make
+        (Ramdisk)
+        (struct
+          include Wodan.StandardSuperblockParams
+
+          let key_size = 20
+
+          let block_size = 256 * 1024
+        end)
+    in
     let value_size = 400 in
-    let disk_size = 32*1024*1024 in
+    let disk_size = 32 * 1024 * 1024 in
     let init () =
       let%lwt disk_res =
-        Ramdisk.create ~name:"bench" ~size_sectors:Int64.(div (of_int disk_size) 512L) ~sector_size:512 in
+        Ramdisk.create ~name:"bench"
+          ~size_sectors:Int64.(div (of_int disk_size) 512L)
+          ~sector_size:512
+      in
       let disk = Rresult.R.get_ok disk_res in
       let%lwt info = Ramdisk.get_info disk in
       Lwt.return (disk, info)
     in
     Nocrypto_entropy_unix.initialize ();
-    let (disk, info) = Lwt_main.run @@ init () in
+    let disk, info = Lwt_main.run @@ init () in
     let data =
       let rec gen count =
         if count = 0 then []
-        else (Stor.key_of_cstruct @@ Nocrypto.Rng.generate Stor.P.key_size,
-              Stor.value_of_string @@ String.make value_size '\x00')
-             ::(gen @@ pred count)
-      in gen count
+        else
+          ( Stor.key_of_cstruct @@ Nocrypto.Rng.generate Stor.P.key_size,
+            Stor.value_of_string @@ String.make value_size '\x00' )
+          :: (gen @@ pred count)
+      in
+      gen count
     in
     let iter () =
       let%lwt root, _gen =
-        Stor.prepare_io (Wodan.FormatEmptyDevice
-                           Int64.(div (mul info.size_sectors @@ of_int info.sector_size) @@ of_int Stor.P.block_size))
+        Stor.prepare_io
+          (Wodan.FormatEmptyDevice
+             Int64.(
+               div (mul info.size_sectors @@ of_int info.sector_size)
+               @@ of_int Stor.P.block_size))
           disk Wodan.standard_mount_options
       in
       (* Sequential, otherwise expect bugs *)
       Lwt_list.iter_s (fun (k, v) -> Stor.insert root k v) data
     in
-    let _samples = Benchmark.latency1 10L ~name:(Printf.sprintf "%d inserts" count) (
-        fun () -> Lwt_main.run (iter ()))
-        () in
+    let _samples =
+      Benchmark.latency1 10L
+        ~name:(Printf.sprintf "%d inserts" count)
+        (fun () -> Lwt_main.run (iter ()))
+        ()
+    in
     ()
 
-  let bench () =
-    begin
-      bench0 10_000;
-      (*bench0 30_000;*)
-    end
+  let bench () = bench0 10_000
+
+  (*bench0 30_000;*)
 
   let fuzz disk =
-    Wodan.read_superblock_params (module B) disk >>= function sb_params ->
-      let module Stor = Wodan.Make(B)(val sb_params) in
-
-    let magiccrc = Cstruct.of_string "\xff\xff\xff\xff" in
-
-    let cstr_cond_reset str =
-      let crcoffset = (Cstruct.len str) - 4 in
-      let crc = Cstruct.sub str crcoffset 4 in
-      if Cstruct.equal crc magiccrc then begin
-        Wodan_crc32c.cstruct_reset str;
-        true
-      end else
-        false
-    in
-
-    let%lwt info = B.get_info disk in
-    let logical_size = Int64.(to_int @@ div (mul info.size_sectors @@ of_int info.sector_size) @@ of_int Stor.P.block_size) in
-    let cstr = Cstruct.create Stor.P.block_size in
-    let%lwt _res = B.read disk 0L [cstr] in
-    if%lwt Lwt.return @@ cstr_cond_reset @@ Cstruct.sub cstr 0 Wodan.sizeof_superblock then
-      B.write disk 0L [cstr] >|= ignore
-    >>= fun _ ->
-    for%lwt i = 1 to logical_size - 1 do
-      let doffset = Int64.(mul (of_int i) @@ of_int Stor.P.block_size) in
-      let%lwt _res = B.read disk doffset [cstr] in
-      if%lwt Lwt.return @@ cstr_cond_reset cstr then
-        B.write disk doffset [cstr]
-      >|= ignore
-    done >>= fun _ ->
-    let%lwt root, _rgen =
-    Stor.prepare_io Wodan.OpenExistingDevice disk Wodan.standard_mount_options in
-    let key = Stor.key_of_string "abcdefghijklmnopqrst" in
-    let cval = Stor.value_of_string "sqnlnfdvulnqsvfjlllsvqoiuuoezr" in
-    Stor.insert root key cval >>= fun () ->
-    Stor.flush root >>= fun _gen ->
-    let%lwt cval1 = Stor.lookup root key >|= unwrap_opt in
-    assert (Cstruct.equal
-      (Stor.cstruct_of_value cval)
-      (Stor.cstruct_of_value cval1));
-    let%lwt root, _rgen =
-      Stor.prepare_io Wodan.OpenExistingDevice disk Wodan.standard_mount_options in
-    let%lwt cval2 = Stor.lookup root key >|= unwrap_opt in
-    assert (Cstruct.equal
-      (Stor.cstruct_of_value cval)
-      (Stor.cstruct_of_value cval2));
-    Lwt.return ()
+    Wodan.read_superblock_params (module B) disk
+    >>= function
+    | sb_params ->
+        let module Stor = Wodan.Make (B) ((val sb_params)) in
+        let magiccrc = Cstruct.of_string "\xff\xff\xff\xff" in
+        let cstr_cond_reset str =
+          let crcoffset = Cstruct.len str - 4 in
+          let crc = Cstruct.sub str crcoffset 4 in
+          if Cstruct.equal crc magiccrc then (
+            Wodan_crc32c.cstruct_reset str;
+            true )
+          else false
+        in
+        let%lwt info = B.get_info disk in
+        let logical_size =
+          Int64.(
+            to_int
+            @@ div (mul info.size_sectors @@ of_int info.sector_size)
+            @@ of_int Stor.P.block_size)
+        in
+        let cstr = Cstruct.create Stor.P.block_size in
+        let%lwt _res = B.read disk 0L [cstr] in
+        if%lwt
+          Lwt.return
+          @@ cstr_cond_reset
+          @@ Cstruct.sub cstr 0 Wodan.sizeof_superblock
+        then (
+          B.write disk 0L [cstr]
+          >|= ignore
+          >>= fun _ ->
+          for%lwt i = 1 to logical_size - 1 do
+            let doffset =
+              Int64.(mul (of_int i) @@ of_int Stor.P.block_size)
+            in
+            let%lwt _res = B.read disk doffset [cstr] in
+            if%lwt Lwt.return @@ cstr_cond_reset cstr then
+              B.write disk doffset [cstr] >|= ignore
+          done
+          >>= fun _ ->
+          let%lwt root, _rgen =
+            Stor.prepare_io Wodan.OpenExistingDevice disk
+              Wodan.standard_mount_options
+          in
+          let key = Stor.key_of_string "abcdefghijklmnopqrst" in
+          let cval = Stor.value_of_string "sqnlnfdvulnqsvfjlllsvqoiuuoezr" in
+          Stor.insert root key cval
+          >>= fun () ->
+          Stor.flush root
+          >>= fun _gen ->
+          let%lwt cval1 = Stor.lookup root key >|= unwrap_opt in
+          assert (
+            Cstruct.equal
+              (Stor.cstruct_of_value cval)
+              (Stor.cstruct_of_value cval1) );
+          let%lwt root, _rgen =
+            Stor.prepare_io Wodan.OpenExistingDevice disk
+              Wodan.standard_mount_options
+          in
+          let%lwt cval2 = Stor.lookup root key >|= unwrap_opt in
+          assert (
+            Cstruct.equal
+              (Stor.cstruct_of_value cval)
+              (Stor.cstruct_of_value cval2) );
+          Lwt.return () )
 end

--- a/src/wodan-unix/wodanc.ml
+++ b/src/wodan-unix/wodanc.ml
@@ -1,207 +1,216 @@
-(*************************************************************************************)
-(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                          *)
-(*                                                                                   *)
-(*  Permission to use, copy, modify, and/or distribute this software for any         *)
-(*  purpose with or without fee is hereby granted, provided that the above           *)
-(*  copyright notice and this permission notice appear in all copies.                *)
-(*                                                                                   *)
-(*  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH    *)
-(*  REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND  *)
-(*  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,         *)
-(*  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM      *)
-(*  LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR    *)
-(*  OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR           *)
-(*  PERFORMANCE OF THIS SOFTWARE.                                                    *)
-(*                                                                                   *)
-(*************************************************************************************)
+(******************************************************************************)
+(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                   *)
+(*                                                                            *)
+(* Permission to use, copy, modify, and/or distribute this software for any   *)
+(* purpose with or without fee is hereby granted, provided that the above     *)
+(* copyright notice and this permission notice appear in all copies.          *)
+(*                                                                            *)
+(* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES   *)
+(* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF           *)
+(* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR    *)
+(* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES     *)
+(* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN      *)
+(* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR *)
+(* IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.                *)
+(*                                                                            *)
+(******************************************************************************)
 
 open Lwt.Infix
-open Cmdliner (* Arg, Manpage, Term *)
+open Cmdliner
+
+(* Arg, Manpage, Term *)
 
 let _ = Printexc.record_backtrace true
 
-module Unikernel1 = Unikernel.Client(Block)
+module Unikernel1 = Unikernel.Client (Block)
 
 let () = Logs.set_reporter (Logs.format_reporter ())
+
 (*let () = Logs.set_level (Some Logs.Info)*)
 
 (* Implementations *)
 
-type copts = { disk : string; }
+type copts = {disk : string}
 
 let dump copts _prefix =
-  Lwt_main.run (
-    Block.connect copts.disk
+  Lwt_main.run
+    ( Block.connect copts.disk
     >>= fun bl ->
-    Nocrypto_entropy_lwt.initialize ()
-    >>= fun _nc ->
-    Unikernel1.dump bl)
+    Nocrypto_entropy_lwt.initialize () >>= fun _nc -> Unikernel1.dump bl )
 
 let restore copts =
-  Lwt_main.run (
-    Block.connect copts.disk
+  Lwt_main.run
+    ( Block.connect copts.disk
     >>= fun bl ->
-    Nocrypto_entropy_lwt.initialize ()
-    >>= fun _nc ->
-    Unikernel1.restore bl)
+    Nocrypto_entropy_lwt.initialize () >>= fun _nc -> Unikernel1.restore bl )
 
 let format copts key_size block_size =
-  Lwt_main.run (
-    Block.connect copts.disk
+  Lwt_main.run
+    ( Block.connect copts.disk
     >>= fun bl ->
     Nocrypto_entropy_lwt.initialize ()
-    >>= fun _nc ->
-    Unikernel1.format bl key_size block_size)
+    >>= fun _nc -> Unikernel1.format bl key_size block_size )
 
 let trim copts =
-  Lwt_main.run (
-    Block.connect copts.disk
+  Lwt_main.run
+    ( Block.connect copts.disk
     >>= fun bl ->
     Nocrypto_entropy_lwt.initialize ()
-    >>= fun _nc ->
-    Unikernel1.trim bl
-    >|= ignore)
+    >>= fun _nc -> Unikernel1.trim bl >|= ignore )
 
 let exercise copts block_size =
-  Lwt_main.run (
-    Block.connect copts.disk
+  Lwt_main.run
+    ( Block.connect copts.disk
     >>= fun bl ->
     Nocrypto_entropy_lwt.initialize ()
-    >>= fun _nc ->
-    Unikernel1.exercise bl block_size
-    >|= ignore)
+    >>= fun _nc -> Unikernel1.exercise bl block_size >|= ignore )
 
 let bench _copts =
   (* Unlike the other functions, don't run within Lwt
      Also ignore the disk in copts to use our own ramdisk *)
-    Unikernel1.bench ()
+  Unikernel1.bench ()
 
 let fuzz copts =
-(* Persistent mode disabled, results are not stable,
+  (* Persistent mode disabled, results are not stable,
    maybe due to CRC munging. *)
-AflPersistent.run (fun () ->
-  Lwt_main.run (
-    Block.connect copts.disk
-    >>= fun bl ->
-    Unikernel1.fuzz bl))
+  AflPersistent.run (fun () ->
+      Lwt_main.run (Block.connect copts.disk >>= fun bl -> Unikernel1.fuzz bl)
+  )
 
-let help _copts man_format cmds topic = match topic with
-| None -> `Help (`Pager, None) (* help about the program. *)
-| Some topic ->
-    let topics = "topics" :: cmds in
-    let conv, _ = Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
-    match conv topic with
-    | `Error e -> `Error (false, e)
-    | `Ok t when t = "topics" -> List.iter print_endline topics; `Ok ()
-    | `Ok t when List.mem t cmds -> `Help (man_format, Some t)
-    | `Ok _t ->
-        let page = (topic, 7, "", "", ""), [`S topic; `P "Placeholder";] in
-        `Ok (Manpage.print man_format Format.std_formatter page)
+let help _copts man_format cmds topic =
+  match topic with
+  | None ->
+      `Help (`Pager, None) (* help about the program. *)
+  | Some topic -> (
+      let topics = "topics" :: cmds in
+      let conv, _ = Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
+      match conv topic with
+      | `Error e ->
+          `Error (false, e)
+      | `Ok t
+        when t = "topics" ->
+          List.iter print_endline topics;
+          `Ok ()
+      | `Ok t
+        when List.mem t cmds ->
+          `Help (man_format, Some t)
+      | `Ok _t ->
+          let page = ((topic, 7, "", "", ""), [`S topic; `P "Placeholder"]) in
+          `Ok (Manpage.print man_format Format.std_formatter page) )
 
 (* Options common to all commands *)
 
 (* TODO: support ramdisks *)
-let copts disk = { disk; }
+let copts disk = {disk}
+
 let copts_t =
   let docs = Manpage.s_common_options in
   let disk =
     let doc = "Disk to operate on." in
-    Arg.(required & pos 0 (some string) None & info [] ~docv:"DISK" ~docs ~doc)
+    Arg.(
+      required & pos 0 (some string) None & info [] ~docv:"DISK" ~docs ~doc)
   in
   Term.(const copts $ disk)
 
 (* Commands *)
 
 let dump_cmd =
-  let prefix = Arg.(value & pos 1 (some string) None & info [] ~docv:"PREFIX") in
+  let prefix =
+    Arg.(value & pos 1 (some string) None & info [] ~docv:"PREFIX")
+  in
   let doc = "dump filesystem to standard output" in
   let exits = Term.default_exits in
-  let man = [
-    `S Manpage.s_description;
-    `P "Dumps the current filesystem to standard output.
-        Format is base64-encoded tab-separated values.";
-    ]
+  let man =
+    [ `S Manpage.s_description;
+      `P
+        "Dumps the current filesystem to standard output.\n\
+        \        Format is base64-encoded tab-separated values." ]
   in
-  Term.(const dump $ copts_t $ prefix),
-  Term.info "dump" ~doc ~sdocs:Manpage.s_common_options ~exits ~man
+  ( Term.(const dump $ copts_t $ prefix),
+    Term.info "dump" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
 
 let restore_cmd =
   let doc = "load filesystem contents from standard input" in
   let exits = Term.default_exits in
   let man =
-    [`S Manpage.s_description;
-     `P "Loads dump output from standard input, inserts it
-         as filesystem contents.";
-  ]
+    [ `S Manpage.s_description;
+      `P
+        "Loads dump output from standard input, inserts it\n\
+        \         as filesystem contents." ]
   in
-  Term.(const restore $ copts_t),
-  Term.info "restore" ~doc ~sdocs:Manpage.s_common_options ~exits ~man
+  ( Term.(const restore $ copts_t),
+    Term.info "restore" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
 
 let format_cmd =
   let doc = "Use a key size of $(docv) bytes." in
-  let key_size = Arg.(
-      value & opt int Wodan.StandardSuperblockParams.key_size
-      & info ["key-size"] ~docv:"BYTES" ~doc) in
+  let key_size =
+    Arg.(
+      value
+      & opt int Wodan.StandardSuperblockParams.key_size
+      & info ["key-size"] ~docv:"BYTES" ~doc)
+  in
   let doc = "Use a block size of $(docv) bytes." in
-  let block_size = Arg.(
-      value & opt int Wodan.StandardSuperblockParams.block_size
-      & info ["block-size"] ~docv:"BYTES" ~doc) in
+  let block_size =
+    Arg.(
+      value
+      & opt int Wodan.StandardSuperblockParams.block_size
+      & info ["block-size"] ~docv:"BYTES" ~doc)
+  in
   let doc = "Format a zeroed filesystem" in
   let exits = Term.default_exits in
   let man =
-    [`S Manpage.s_description;
-     `P "Format a filesystem that has been zeroed beforehand.";
-  ]
+    [ `S Manpage.s_description;
+      `P "Format a filesystem that has been zeroed beforehand." ]
   in
-  Term.(const format $ copts_t $ key_size $ block_size),
-  Term.info "format" ~doc ~sdocs:Manpage.s_common_options ~exits ~man
+  ( Term.(const format $ copts_t $ key_size $ block_size),
+    Term.info "format" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
 
 let trim_cmd =
   let doc = "Trim an existing filesystem" in
   let exits = Term.default_exits in
   let man =
-    [`S Manpage.s_description;
-     `P "Discard unused blocks from an existing filesystem.
-         This scans the disk for in-use blocks and discards
-         the rest.";
-    ]
+    [ `S Manpage.s_description;
+      `P
+        "Discard unused blocks from an existing filesystem.\n\
+        \         This scans the disk for in-use blocks and discards\n\
+        \         the rest." ]
   in
-  Term.(const trim $ copts_t),
-  Term.info "trim" ~doc ~sdocs:Manpage.s_common_options ~exits ~man
+  ( Term.(const trim $ copts_t),
+    Term.info "trim" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
 
 let exercise_cmd =
-  let block_size = Arg.(value & pos 1 (some int) None & info [] ~docv:"block_size") in
+  let block_size =
+    Arg.(value & pos 1 (some int) None & info [] ~docv:"block_size")
+  in
   let doc = "Create a fresh filesystem, exercise and fill it" in
   let man =
-    [`S Manpage.s_description;
-     `P "Create a fresh filesystem, exercise and fill it.
-         This creates a filesystem, runs a few pre-defined operations
-         and fills it with random data.";
-    ]
+    [ `S Manpage.s_description;
+      `P
+        "Create a fresh filesystem, exercise and fill it.\n\
+        \         This creates a filesystem, runs a few pre-defined operations\n\
+        \         and fills it with random data." ]
   in
-  Term.(const exercise $ copts_t $ block_size),
-  Term.info "exercise" ~doc ~man
+  ( Term.(const exercise $ copts_t $ block_size),
+    Term.info "exercise" ~doc ~man )
 
 let bench_cmd =
   let doc = "Run a standardised micro-benchmark" in
   let man =
-    [`S Manpage.s_description;
-     `P "Run a micro-benchmark that does bulk insertions without flushing.";
+    [ `S Manpage.s_description;
+      `P "Run a micro-benchmark that does bulk insertions without flushing."
     ]
   in
-  Term.(const bench $ copts_t),
-  Term.info "bench" ~doc ~man
+  (Term.(const bench $ copts_t), Term.info "bench" ~doc ~man)
 
 let fuzz_cmd =
   let doc = "Fuzz a filesystem" in
   let exits = Term.default_exits in
   let man =
-    [`S Manpage.s_description;
-     `P "Runs a few operations on a fuzzer-generated filesystem.";
-    ]
+    [ `S Manpage.s_description;
+      `P "Runs a few operations on a fuzzer-generated filesystem." ]
   in
-  Term.(const fuzz $ copts_t),
-  Term.info "fuzz" ~doc ~sdocs:Manpage.s_common_options ~exits ~man
+  ( Term.(const fuzz $ copts_t),
+    Term.info "fuzz" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
 
 let help_cmd =
   let topic =
@@ -210,24 +219,28 @@ let help_cmd =
   in
   let doc = "display help about wodanc and wodanc subcommands" in
   let man =
-    [`S Manpage.s_description;
-     `P "Prints help about wodanc commands and other subjects...";
-    ]
+    [ `S Manpage.s_description;
+      `P "Prints help about wodanc commands and other subjects..." ]
   in
-  Term.(ret
-          (const help $ copts_t $ Arg.man_format $ Term.choice_names $topic)),
-  Term.info "help" ~doc ~exits:Term.default_exits ~man
+  ( Term.(
+      ret (const help $ copts_t $ Arg.man_format $ Term.choice_names $ topic)),
+    Term.info "help" ~doc ~exits:Term.default_exits ~man )
 
 let default_cmd =
   let doc = "CLI for Wodan filesystems" in
   let sdocs = Manpage.s_common_options in
   let exits = Term.default_exits in
-  Term.(ret (const (fun _ -> `Help (`Pager, None)) $ copts_t)),
-  Term.info "wodanc" ~doc ~sdocs ~exits
+  ( Term.(ret (const (fun _ -> `Help (`Pager, None)) $ copts_t)),
+    Term.info "wodanc" ~doc ~sdocs ~exits )
 
-let cmds = [restore_cmd; dump_cmd; format_cmd;
-            trim_cmd; exercise_cmd; bench_cmd; fuzz_cmd; help_cmd]
+let cmds =
+  [ restore_cmd;
+    dump_cmd;
+    format_cmd;
+    trim_cmd;
+    exercise_cmd;
+    bench_cmd;
+    fuzz_cmd;
+    help_cmd ]
 
-let () =
-  Term.(exit @@ eval_choice default_cmd cmds)
-
+let () = Term.(exit @@ eval_choice default_cmd cmds)

--- a/src/wodan/wodan.ml
+++ b/src/wodan/wodan.ml
@@ -1,106 +1,132 @@
-(*************************************************************************************)
-(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                          *)
-(*                                                                                   *)
-(*  Permission to use, copy, modify, and/or distribute this software for any         *)
-(*  purpose with or without fee is hereby granted, provided that the above           *)
-(*  copyright notice and this permission notice appear in all copies.                *)
-(*                                                                                   *)
-(*  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH    *)
-(*  REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND  *)
-(*  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,         *)
-(*  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM      *)
-(*  LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR    *)
-(*  OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR           *)
-(*  PERFORMANCE OF THIS SOFTWARE.                                                    *)
-(*                                                                                   *)
-(*************************************************************************************)
+(******************************************************************************)
+(*  Copyright 2017 Gabriel de Perthuis <g2p.code@gmail.com>                   *)
+(*                                                                            *)
+(* Permission to use, copy, modify, and/or distribute this software for any   *)
+(* purpose with or without fee is hereby granted, provided that the above     *)
+(* copyright notice and this permission notice appear in all copies.          *)
+(*                                                                            *)
+(* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES   *)
+(* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF           *)
+(* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR    *)
+(* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES     *)
+(* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN      *)
+(* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR *)
+(* IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.                *)
+(*                                                                            *)
+(******************************************************************************)
 
 open Lwt.Infix
 open Sexplib.Std
 
 let superblock_magic = "MIRAGE KVFS \xf0\x9f\x90\xaa"
+
 let superblock_version = 1l
+
 let max_dirty = 128
 
-
 exception BadMagic
+
 exception BadVersion
+
 exception BadFlags
+
 exception BadCRC of int64
+
 exception BadParams
 
 exception ReadError
+
 exception WriteError
+
 exception OutOfSpace
+
 exception NeedsFlush
 
 exception BadKey of string
+
 exception ValueTooLarge of string
+
 exception BadNodeType of int
+
 exception BadNodeFSID of string
 
 module type EXTBLOCK = sig
   include Mirage_types_lwt.BLOCK
-  val discard: t -> int64 -> int64 -> (unit, write_error) result io
+
+  val discard : t -> int64 -> int64 -> (unit, write_error) result io
 end
 
-module BlockCompat (B: Mirage_types_lwt.BLOCK) : EXTBLOCK with
-  type t = B.t
-= struct
+module BlockCompat (B : Mirage_types_lwt.BLOCK) : EXTBLOCK with type t = B.t =
+struct
   include B
+
   let discard _ _ _ = Lwt.return @@ Ok ()
 end
 
 (* Incompatibility flags *)
 let sb_incompat_rdepth = 1l
+
 let sb_incompat_fsid = 2l
+
 let sb_incompat_value_count = 4l
-let sb_required_incompat = Int32.logor sb_incompat_rdepth
+
+let sb_required_incompat =
+  Int32.logor sb_incompat_rdepth
   @@ Int32.logor sb_incompat_fsid sb_incompat_value_count
 
 [@@@warning "-32"]
 
 (* 512 bytes.  The rest of the block isn't crc-controlled. *)
-[%%cstruct type superblock = {
-  magic: uint8_t [@len 16];
+[%%cstruct
+type superblock = {
+  magic : uint8_t; [@len 16]
   (* major version, all later fields may change if this does *)
-  version: uint32_t;
-  compat_flags: uint32_t;
+  version : uint32_t;
+  compat_flags : uint32_t;
   (* refuse to mount if unknown incompat_flags are set *)
-  incompat_flags: uint32_t;
-  block_size: uint32_t;
-  key_size: uint8_t;
-  first_block_written: uint64_t;
-  logical_size: uint64_t;
+  incompat_flags : uint32_t;
+  block_size : uint32_t;
+  key_size : uint8_t;
+  first_block_written : uint64_t;
+  logical_size : uint64_t;
   (* FSID is UUID-sized (128 bits) *)
-  fsid: uint8_t [@len 16];
-  reserved: uint8_t [@len 443];
-  crc: uint32_t;
-}[@@little_endian]]
+  fsid : uint8_t; [@len 16]
+  reserved : uint8_t; [@len 443]
+  crc : uint32_t
+}
+[@@little_endian]]
 
 let () = assert (String.length superblock_magic = 16)
+
 let () = assert (sizeof_superblock = 512)
 
 let sizeof_crc = 4
 
-[%%cstruct type anynode_hdr = {
-  nodetype: uint8_t;
-  generation: uint64_t;
-  fsid: uint8_t [@len 16];
-  value_count: uint32_t;
-}[@@little_endian]]
+[%%cstruct
+type anynode_hdr = {
+  nodetype : uint8_t;
+  generation : uint64_t;
+  fsid : uint8_t; [@len 16]
+  value_count : uint32_t
+}
+[@@little_endian]]
+
 let () = assert (sizeof_anynode_hdr = 29)
 
-[%%cstruct type rootnode_hdr = {
+[%%cstruct
+type rootnode_hdr = {
   (* nodetype = 1 *)
-  nodetype: uint8_t;
+  nodetype : uint8_t;
   (* will this wrap? there's no uint128_t. Nah, flash will wear out first. *)
-  generation: uint64_t;
-  fsid: uint8_t [@len 16];
-  value_count: uint32_t;
-  depth: uint32_t;
-}[@@little_endian]]
+  generation : uint64_t;
+  fsid : uint8_t; [@len 16]
+  value_count : uint32_t;
+  depth : uint32_t
+}
+[@@little_endian]]
+
 let () = assert (sizeof_rootnode_hdr = 33)
+
 (* Contents: logged data, and child node links *)
 (* All node types end with a CRC *)
 (* rootnode_hdr
@@ -109,14 +135,18 @@ let () = assert (sizeof_rootnode_hdr = 33)
  * child links: (key, logical offset)*, grow from the right end towards the left
  * crc *)
 
-[%%cstruct type childnode_hdr = {
+[%%cstruct
+type childnode_hdr = {
   (* nodetype = 2 *)
-  nodetype: uint8_t;
-  generation: uint64_t;
-  fsid: uint8_t [@len 16];
-  value_count: uint32_t;
-}[@@little_endian]]
+  nodetype : uint8_t;
+  generation : uint64_t;
+  fsid : uint8_t; [@len 16]
+  value_count : uint32_t
+}
+[@@little_endian]]
+
 let () = assert (sizeof_childnode_hdr = 29)
+
 (* Contents: logged data, and child node links *)
 (* Layout: see above *)
 
@@ -131,202 +161,212 @@ let make_fanned_io_list size cstr =
   let l = Cstruct.len cstr in
   let rec iter off =
     if off = 0 then ()
-    else begin
+    else
       let off = off - size in
-      r := (Cstruct.sub cstr off size)::!r;
+      r := Cstruct.sub cstr off size :: !r;
       iter off
-    end in
-  iter l;
-  !r
+  in
+  iter l; !r
 
-let _sb_io block_io =
-  Cstruct.sub block_io 0 sizeof_superblock
+let _sb_io block_io = Cstruct.sub block_io 0 sizeof_superblock
 
 type statistics = {
-  mutable inserts: int;
-  mutable lookups: int;
-  mutable range_searches: int;
-  mutable iters: int;
+  mutable inserts : int;
+  mutable lookups : int;
+  mutable range_searches : int;
+  mutable iters : int
 }
 
-let default_statistics = {
-  inserts=0;
-  lookups=0;
-  range_searches=0;
-  iters=0;
-}
+let default_statistics =
+  {inserts = 0; lookups = 0; range_searches = 0; iters = 0}
 
 type childlinks = {
   (* starts at block_size - sizeof_crc, if there are no children *)
-  mutable childlinks_offset: int;
+  mutable childlinks_offset : int
 }
 
-type node = [
-  |`Root
-  |`Child]
+type node =
+  [ `Root
+  | `Child ]
 
 let header_size = function
-  |`Root -> sizeof_rootnode_hdr
-  |`Child -> sizeof_childnode_hdr
+  | `Root ->
+      sizeof_rootnode_hdr
+  | `Child ->
+      sizeof_childnode_hdr
 
-let string_dump key =
-  Cstruct.hexdump @@ Cstruct.of_string key
+let string_dump key = Cstruct.hexdump @@ Cstruct.of_string key
 
 let src = Logs.Src.create "wodan" ~doc:"logs Wodan operations"
+
 module Logs = (val Logs.src_log src : Logs.LOG)
 
-module BlockIntervals = Diet.Make(struct
+module BlockIntervals = Diet.Make (struct
   include Int64
+
   let t_of_sexp = int64_of_sexp
+
   let sexp_of_t = sexp_of_int64
 end)
 
 let unwrap_opt = function
-  |None -> raise Not_found
-  |Some v -> v
+  | None ->
+      raise Not_found
+  | Some v ->
+      v
 
 module KeyedMap = Wodan_btreemap
+
 (*module KeyedMap = Btreemap*)
-let keyedmap_find k map =
-  unwrap_opt @@ KeyedMap.find_opt k map
-let keyedmap_keys map =
-  KeyedMap.fold (fun k _v acc -> k::acc) map []
-module KeyedSet = Set.Make(String)
+let keyedmap_find k map = unwrap_opt @@ KeyedMap.find_opt k map
+
+let keyedmap_keys map = KeyedMap.fold (fun k _v acc -> k :: acc) map []
+
+module KeyedSet = Set.Make (String)
 
 module LRUKey = struct
   type t = int64
+
   let hash = Hashtbl.hash
+
   let equal = Int64.equal
 end
 
 type logdata_index = {
-  mutable logdata_contents: string KeyedMap.t;
-  mutable value_end: int;
-  mutable old_value_end: int;
+  mutable logdata_contents : string KeyedMap.t;
+  mutable value_end : int;
+  mutable old_value_end : int
 }
 
-type flush_info = {
-  mutable flush_children: int64 KeyedMap.t;
-}
+type flush_info = {mutable flush_children : int64 KeyedMap.t}
 
 type lru_entry = {
-  cached_node: node;
-  mutable parent_key: LRUKey.t option;
+  cached_node : node;
+  mutable parent_key : LRUKey.t option;
   (* A node is flushable iff it's referenced from flush_root
      through a flush_children map.
      We use an option here to make checking for flushability faster.
      A flushable node is either new or dirty, but not both. *)
-  mutable flush_info: flush_info option;
-(* Use offsets so that data isn't duplicated *)
-  mutable children: (int64 KeyedMap.t) Lazy.t;
-(* Don't reference nodes directly, always go through the
+  mutable flush_info : flush_info option;
+  (* Use offsets so that data isn't duplicated *)
+  mutable children : int64 KeyedMap.t Lazy.t;
+  (* Don't reference nodes directly, always go through the
  * LRU to bump recently accessed nodes *)
-  mutable children_alloc_ids: int64 KeyedMap.t;
-  mutable highest_key: string;
-  raw_node: Cstruct.t;
-  io_data: Cstruct.t list;
-  logdata: logdata_index;
-  childlinks: childlinks;
-  mutable prev_logical: int64 option;
+  mutable children_alloc_ids : int64 KeyedMap.t;
+  mutable highest_key : string;
+  raw_node : Cstruct.t;
+  io_data : Cstruct.t list;
+  logdata : logdata_index;
+  childlinks : childlinks;
+  mutable prev_logical : int64 option;
   (* depth counted from the leaves; mutable on the root only *)
-  mutable rdepth: int32;
+  mutable rdepth : int32
 }
 
 module LRUValue = struct
   type t = lru_entry
+
   let weight _val = 1
 end
 
-module LRU = Lru.M.Make(LRUKey)(LRUValue)
+module LRU = Lru.M.Make (LRUKey) (LRUValue)
 
-let lru_get lru alloc_id =
-  LRU.find alloc_id lru
+let lru_get lru alloc_id = LRU.find alloc_id lru
 
-let lru_peek lru alloc_id =
-  LRU.find ~promote:false alloc_id lru
+let lru_peek lru alloc_id = LRU.find ~promote:false alloc_id lru
 
 exception AlreadyCached of LRUKey.t
 
 let lookup_parent_link lru entry =
   match entry.parent_key with
-  |None -> None
-  |Some parent_key ->
+  | None ->
+      None
+  | Some parent_key -> (
     match lru_peek lru parent_key with
-    |None -> failwith "Missing parent"
-    |Some parent_entry ->
-    let children = Lazy.force parent_entry.children in
-    let offset = keyedmap_find entry.highest_key children in
-    Some (parent_key, parent_entry, offset)
+    | None ->
+        failwith "Missing parent"
+    | Some parent_entry ->
+        let children = Lazy.force parent_entry.children in
+        let offset = keyedmap_find entry.highest_key children in
+        Some (parent_key, parent_entry, offset) )
 
 (* Exclusive set *)
 let lru_xset lru alloc_id value =
   if LRU.mem alloc_id lru then raise @@ AlreadyCached alloc_id;
-  let would_discard = ((LRU.size lru) + (LRUValue.weight value) > LRU.capacity lru) in
+  let would_discard =
+    LRU.size lru + LRUValue.weight value > LRU.capacity lru
+  in
   (* assumes uniform weights, looks only at the bottom item *)
-  if would_discard then begin
+  ( if would_discard then
     match LRU.lru lru with
-    |Some (_alloc_id, entry) when entry.flush_info <> None ->
-      failwith "Would discard dirty data" (* TODO expose this as a proper API value *)
-    |Some (_alloc_id, entry) ->
-      begin match lookup_parent_link lru entry with
-      |None -> failwith "Would discard a root key, LRU too small for tree depth"
-      |Some (_parent_key, parent_entry, _offset) ->
-        KeyedMap.remove entry.highest_key parent_entry.children_alloc_ids
-      end
-    |_ -> failwith "LRU capacity is too small"
-  end;
+    | Some (_alloc_id, entry)
+      when entry.flush_info <> None ->
+        failwith "Would discard dirty data"
+        (* TODO expose this as a proper API value *)
+    | Some (_alloc_id, entry) -> (
+      match lookup_parent_link lru entry with
+      | None ->
+          failwith "Would discard a root key, LRU too small for tree depth"
+      | Some (_parent_key, parent_entry, _offset) ->
+          KeyedMap.remove entry.highest_key parent_entry.children_alloc_ids )
+    | _ ->
+        failwith "LRU capacity is too small" );
   LRU.add alloc_id value lru
 
-let lru_create capacity =
-  LRU.create capacity
+let lru_create capacity = LRU.create capacity
 
 type node_cache = {
   (* LRUKey.t -> lru_entry
    * all nodes are keyed by their alloc_id *)
-  lru: LRU.t;
-  mutable flush_root: LRUKey.t option;
-  mutable next_alloc_id: int64;
+  lru : LRU.t;
+  mutable flush_root : LRUKey.t option;
+  mutable next_alloc_id : int64;
   (* The next generation number we'll allocate *)
-  mutable next_generation: int64;
+  mutable next_generation : int64;
   (* The next logical address we'll allocate (if free) *)
-  mutable next_logical_alloc: int64;
+  mutable next_logical_alloc : int64;
   (* Count of free blocks on disk *)
-  mutable free_count: int64;
-  mutable new_count: int64;
-  mutable dirty_count: int64;
-  fsid: string;
-  logical_size: int64;
+  mutable free_count : int64;
+  mutable new_count : int64;
+  mutable dirty_count : int64;
+  fsid : string;
+  logical_size : int64;
   (* Logical -> bit.  Zero iff free. *)
-  space_map: Bitv.t;
-  scan_map: Bitv.t option;
-  mutable freed_intervals: BlockIntervals.t;
-  statistics: statistics;
+  space_map : Bitv.t;
+  scan_map : Bitv.t option;
+  mutable freed_intervals : BlockIntervals.t;
+  statistics : statistics
 }
 
 let bitv_create64 off bit =
-  if Int64.compare off (Int64.of_int max_int) > 0 then failwith (Printf.sprintf "Size %Ld too large for a Bitv" off);
+  if Int64.compare off (Int64.of_int max_int) > 0 then
+    failwith (Printf.sprintf "Size %Ld too large for a Bitv" off);
   Bitv.create (Int64.to_int off) bit
 
-let bitv_set64 vec off bit =
-  Bitv.set vec (Int64.to_int off) bit (* Safe as long as bitv_create64 is used *)
+let bitv_set64 vec off bit = Bitv.set vec (Int64.to_int off) bit
 
-let bitv_get64 vec off =
-  Bitv.get vec (Int64.to_int off) (* Safe as long as bitv_create64 is used *)
+(* Safe as long as bitv_create64 is used *)
 
-let bitv_len64 vec =
-  Int64.of_int @@ Bitv.length vec
+let bitv_get64 vec off = Bitv.get vec (Int64.to_int off)
+
+(* Safe as long as bitv_create64 is used *)
+
+let bitv_len64 vec = Int64.of_int @@ Bitv.length vec
 
 let next_logical_novalid cache logical =
   let log1 = Int64.succ logical in
   if log1 = cache.logical_size then 1L else log1
 
 let next_logical_alloc_valid cache =
-  if cache.free_count = 0L then failwith "Out of space"; (* Not the same as OutOfSpace *)
+  if cache.free_count = 0L then failwith "Out of space";
+  (* Not the same as OutOfSpace *)
   let rec after log =
-    if not @@ bitv_get64 cache.space_map log then log else
-      after @@ next_logical_novalid cache log
-  in let loc = after cache.next_logical_alloc in
-  cache.next_logical_alloc <- next_logical_novalid cache loc; loc
+    if not @@ bitv_get64 cache.space_map log then log
+    else after @@ next_logical_novalid cache log
+  in
+  let loc = after cache.next_logical_alloc in
+  cache.next_logical_alloc <- next_logical_novalid cache loc;
+  loc
 
 let next_alloc_id cache =
   let r = cache.next_alloc_id in
@@ -343,41 +383,46 @@ let int64_pred_nowrap va =
   else Int64.pred va
 
 type insertable =
-  |InsValue of string
-  |InsChild of int64 * int64 option (* loc, alloc_id *)
-  (*|InsTombstone*) (* use empty values for now *)
+  | InsValue of string
+  | InsChild of int64 * int64 option
+
+(* loc, alloc_id *)
+
+(*|InsTombstone*)
+(* use empty values for now *)
 
 type insert_space =
-  |InsSpaceValue of int
-  |InsSpaceChild of int
+  | InsSpaceValue of int
+  | InsSpaceChild of int
 
 let rec _reserve_dirty_rec cache alloc_id new_count dirty_count =
   (*Logs.debug (fun m -> m "_reserve_dirty_rec %Ld" alloc_id);*)
   match lru_get cache.lru alloc_id with
-  |None -> failwith "Missing LRU key"
-  |Some entry -> begin
-      match entry.flush_info with
-      |Some _di -> ()
-      |None -> begin
-          match entry.cached_node with
-          |`Root -> ()
-          |`Child ->
-            match entry.parent_key with
-            |Some parent_key -> begin
-                match lru_get cache.lru parent_key with
-                |None -> failwith "missing parent_entry"
-                |Some _parent_entry -> _reserve_dirty_rec cache parent_key new_count dirty_count
-              end
-            |None -> failwith "entry.parent_key inconsistent (no parent)";
-        end;
-        begin
+  | None ->
+      failwith "Missing LRU key"
+  | Some entry -> (
+    match entry.flush_info with
+    | Some _di ->
+        ()
+    | None -> (
+        ( match entry.cached_node with
+        | `Root ->
+            ()
+        | `Child -> (
+          match entry.parent_key with
+          | Some parent_key -> (
+            match lru_get cache.lru parent_key with
+            | None ->
+                failwith "missing parent_entry"
+            | Some _parent_entry ->
+                _reserve_dirty_rec cache parent_key new_count dirty_count )
+          | None ->
+              failwith "entry.parent_key inconsistent (no parent)" ) );
         match entry.prev_logical with
-        |None ->
+        | None ->
             new_count := Int64.succ !new_count
-        |Some _plog ->
-            dirty_count := Int64.succ !dirty_count
-        end;
-  end
+        | Some _plog ->
+            dirty_count := Int64.succ !dirty_count ) )
 
 let _reserve_dirty cache alloc_id new_count depth =
   (*Logs.debug (fun m -> m "_reserve_dirty %Ld" alloc_id);*)
@@ -386,193 +431,252 @@ let _reserve_dirty cache alloc_id new_count depth =
   _reserve_dirty_rec cache alloc_id new_count dirty_count;
   (*Logs.debug (fun m -> m "_reserve_dirty %Ld free %Ld allocs N %Ld D %Ld counter N %Ld D %Ld depth %Ld"
              alloc_id cache.free_count cache.new_count cache.dirty_count !new_count !dirty_count depth);*)
-  if Int64.(compare cache.free_count @@ add cache.dirty_count @@ add !dirty_count @@ add cache.new_count !new_count) < 0 then begin
-    if Int64.(compare cache.free_count @@ add !dirty_count @@ add cache.new_count @@ add !new_count @@ succ depth) >= 0 then
-      raise NeedsFlush (* flush and retry, it will succeed *)
-    else
-      raise OutOfSpace (* flush if you like, but retrying will not succeed *)
-  end
+  if
+    Int64.(
+      compare cache.free_count
+      @@ add cache.dirty_count
+      @@ add !dirty_count
+      @@ add cache.new_count !new_count)
+    < 0
+  then
+    if
+      Int64.(
+        compare cache.free_count
+        @@ add !dirty_count
+        @@ add cache.new_count
+        @@ add !new_count
+        @@ succ depth)
+      >= 0
+    then raise NeedsFlush (* flush and retry, it will succeed *)
+    else raise OutOfSpace
+
+(* flush if you like, but retrying will not succeed *)
 
 let rec _mark_dirty cache alloc_id : flush_info =
   (*Logs.debug (fun m -> m "_mark_dirty %Ld" alloc_id);*)
   match lru_get cache.lru alloc_id with
-  |None -> failwith "Missing LRU key"
-  |Some entry -> begin
-      match entry.flush_info with
-      |Some di -> di
-      |None -> begin
-          match entry.cached_node with
-          |`Root ->
-            begin match cache.flush_root with
-              |None -> cache.flush_root <- Some alloc_id
-              |_ -> failwith "flush_root inconsistent" end
-          |`Child ->
-            match entry.parent_key with
-            |Some parent_key -> begin
-                match lru_get cache.lru parent_key with
-                |None -> failwith "missing parent_entry"
-                |Some _parent_entry ->
-                    let parent_di = _mark_dirty cache parent_key in
-                    begin
-                      if KeyedMap.exists (fun _k lk -> lk = alloc_id) parent_di.flush_children then
-                        failwith "dirty_node inconsistent" else
-                        KeyedMap.add entry.highest_key alloc_id parent_di.flush_children
-                    end
-              end
-            |None -> failwith "entry.parent_key inconsistent (no parent)";
-        end;
-        let di = { flush_children=KeyedMap.create (); } in
-        entry.flush_info <- Some di;
-        begin
-        match entry.prev_logical with
-        |None ->
-          cache.new_count <- Int64.succ cache.new_count;
-          if Int64.(compare (add cache.new_count cache.dirty_count) cache.free_count) > 0 then failwith "Out of space"; (* Not the same as OutOfSpace *)
-        |Some _plog ->
-          cache.dirty_count <- Int64.succ cache.dirty_count;
-          if Int64.(compare (add cache.new_count cache.dirty_count) cache.free_count) > 0 then failwith "Out of space";
-        end;
+  | None ->
+      failwith "Missing LRU key"
+  | Some entry -> (
+    match entry.flush_info with
+    | Some di ->
         di
-    end
+    | None ->
+        ( match entry.cached_node with
+        | `Root -> (
+          match cache.flush_root with
+          | None ->
+              cache.flush_root <- Some alloc_id
+          | _ ->
+              failwith "flush_root inconsistent" )
+        | `Child -> (
+          match entry.parent_key with
+          | Some parent_key -> (
+            match lru_get cache.lru parent_key with
+            | None ->
+                failwith "missing parent_entry"
+            | Some _parent_entry ->
+                let parent_di = _mark_dirty cache parent_key in
+                if
+                  KeyedMap.exists
+                    (fun _k lk -> lk = alloc_id)
+                    parent_di.flush_children
+                then failwith "dirty_node inconsistent"
+                else
+                  KeyedMap.add entry.highest_key alloc_id
+                    parent_di.flush_children )
+          | None ->
+              failwith "entry.parent_key inconsistent (no parent)" ) );
+        let di = {flush_children = KeyedMap.create ()} in
+        entry.flush_info <- Some di;
+        ( match entry.prev_logical with
+        | None ->
+            cache.new_count <- Int64.succ cache.new_count;
+            if
+              Int64.(
+                compare
+                  (add cache.new_count cache.dirty_count)
+                  cache.free_count)
+              > 0
+            then failwith "Out of space" (* Not the same as OutOfSpace *)
+        | Some _plog ->
+            cache.dirty_count <- Int64.succ cache.dirty_count;
+            if
+              Int64.(
+                compare
+                  (add cache.new_count cache.dirty_count)
+                  cache.free_count)
+              > 0
+            then failwith "Out of space" );
+        di )
 
 let _get_superblock_io () =
   (* This will only work on Unix, which has buffered IO instead of direct IO.
   TODO figure out portability *)
-    Cstruct.create 512
+  Cstruct.create 512
 
 type mount_options = {
   (* Whether the empty value should be considered a tombstone,
    * meaning that `mem` will return no value when finding it *)
-  has_tombstone: bool;
+  has_tombstone : bool;
   (* If enabled, instead of checking the entire filesystem when opening,
    * leaf nodes won't be scanned.  They will be scanned on open instead. *)
-  fast_scan: bool;
+  fast_scan : bool;
   (* How many blocks to keep in cache *)
-  cache_size: int;
+  cache_size : int
 }
 
 (* All parameters that can be read from the superblock *)
 module type SUPERBLOCK_PARAMS = sig
   (* Size of blocks, in bytes *)
-  val block_size: int
+  val block_size : int
+
   (* The exact size of all keys, in bytes *)
-  val key_size: int
+  val key_size : int
 end
 
 module type PARAMS = sig
   include SUPERBLOCK_PARAMS
 end
 
-let standard_mount_options = {
-  has_tombstone=false;
-  fast_scan=true;
-  cache_size=1024;
-}
+let standard_mount_options =
+  {has_tombstone = false; fast_scan = true; cache_size = 1024}
 
 module StandardSuperblockParams : SUPERBLOCK_PARAMS = struct
-  let block_size = 256*1024
+  let block_size = 256 * 1024
+
   let key_size = 20
 end
 
 type deviceOpenMode =
-  |OpenExistingDevice
-  |FormatEmptyDevice of int64
+  | OpenExistingDevice
+  | FormatEmptyDevice of int64
 
 module type S = sig
   type key
+
   type value
+
   type disk
+
   type root
 
   module Key : sig
     include Hashtbl.HashedType with type t = key
+
     include Map.OrderedType with type t := key
   end
 
   module P : PARAMS
 
   val key_of_cstruct : Cstruct.t -> key
+
   val key_of_string : string -> key
+
   val key_of_string_padded : string -> key
+
   val cstruct_of_key : key -> Cstruct.t
+
   val string_of_key : key -> string
+
   val value_of_cstruct : Cstruct.t -> value
+
   val value_of_string : string -> value
+
   val value_equal : value -> value -> bool
+
   val cstruct_of_value : value -> Cstruct.t
+
   val string_of_value : value -> string
+
   val next_key : key -> key
+
   val is_tombstone : root -> value -> bool
 
   val insert : root -> key -> value -> unit Lwt.t
+
   val lookup : root -> key -> value option Lwt.t
+
   val mem : root -> key -> bool Lwt.t
+
   val flush : root -> int64 Lwt.t
+
   val fstrim : root -> int64 Lwt.t
+
   val live_trim : root -> int64 Lwt.t
+
   val log_statistics : root -> unit
-  val search_range : root
-    -> key (* start inclusive *)
-    -> key (* end exclusive *)
-    -> (key -> value -> unit)
-    -> unit Lwt.t
+
+  val search_range :
+    root ->
+    key (* start inclusive *) ->
+    key (* end exclusive *) ->
+    (key -> value -> unit) ->
+    unit Lwt.t
+
   val iter : root -> (key -> value -> unit) -> unit Lwt.t
-  val prepare_io : deviceOpenMode -> disk -> mount_options -> (root * int64) Lwt.t
+
+  val prepare_io :
+    deviceOpenMode -> disk -> mount_options -> (root * int64) Lwt.t
 end
 
-let read_superblock_params (type disk) (module B: Mirage_types_lwt.BLOCK with type t = disk) disk =
+let read_superblock_params (type disk)
+    (module B : Mirage_types_lwt.BLOCK with type t = disk) disk =
   let block_io = _get_superblock_io () in
   let block_io_fanned = [block_io] in
-  B.read disk 0L block_io_fanned >>= Lwt.wrap1 begin function
-    |Result.Error _ -> raise ReadError
-    |Result.Ok () ->
-        let sb = _sb_io block_io in
-    if copy_superblock_magic sb <> superblock_magic
-    then raise BadMagic
-    else if get_superblock_version sb <> superblock_version
-    then raise BadVersion
-    else if get_superblock_incompat_flags sb <> sb_required_incompat
-    then raise BadFlags
-    else if not @@ Wodan_crc32c.cstruct_valid sb
-    then raise @@ BadCRC 0L
-    else begin
-      let block_size = Int32.to_int @@ get_superblock_block_size sb in
-      let key_size = get_superblock_key_size sb in
-      (module struct
-        let block_size = block_size
-        let key_size = key_size
-      end : SUPERBLOCK_PARAMS)
-    end
-  end
+  B.read disk 0L block_io_fanned
+  >>= Lwt.wrap1 (function
+        | Result.Error _ ->
+            raise ReadError
+        | Result.Ok () ->
+            let sb = _sb_io block_io in
+            if copy_superblock_magic sb <> superblock_magic then
+              raise BadMagic
+            else if get_superblock_version sb <> superblock_version then
+              raise BadVersion
+            else if get_superblock_incompat_flags sb <> sb_required_incompat
+            then raise BadFlags
+            else if not @@ Wodan_crc32c.cstruct_valid sb then
+              raise @@ BadCRC 0L
+            else
+              let block_size = Int32.to_int @@ get_superblock_block_size sb in
+              let key_size = get_superblock_key_size sb in
+              ( module struct
+                let block_size = block_size
 
-module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = struct
+                let key_size = key_size
+              end
+              : SUPERBLOCK_PARAMS ) )
+
+module Make (B : EXTBLOCK) (P : SUPERBLOCK_PARAMS) : S with type disk = B.t =
+struct
   type key = string
+
   type value = string
+
   type disk = B.t
 
   module P = P
+
   module Key = struct
     include String
+
     let hash = Hashtbl.hash
   end
 
   let key_of_cstruct key =
-    if Cstruct.len key <> P.key_size
-    then raise @@ BadKey (Cstruct.to_string key)
+    if Cstruct.len key <> P.key_size then
+      raise @@ BadKey (Cstruct.to_string key)
     else Cstruct.to_string key
 
   let key_of_string key =
-    if String.length key <> P.key_size
-    then raise @@ BadKey key
-    else key
+    if String.length key <> P.key_size then raise @@ BadKey key else key
 
   let key_of_string_padded key =
-    if String.length key > P.key_size
-    then raise @@ BadKey key
-    else key ^ (String.make (P.key_size - String.length key) '\000')
+    if String.length key > P.key_size then raise @@ BadKey key
+    else key ^ String.make (P.key_size - String.length key) '\000'
 
-  let cstruct_of_key key =
-    Cstruct.of_string key
+  let cstruct_of_key key = Cstruct.of_string key
 
   let string_of_key key = key
 
@@ -580,31 +684,31 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
     let len = String.length value in
     if len >= 65536 then raise @@ ValueTooLarge value else value
 
-  let value_of_cstruct value =
-    value_of_string @@ Cstruct.to_string value
+  let value_of_cstruct value = value_of_string @@ Cstruct.to_string value
 
   let value_equal = String.equal
 
-  let cstruct_of_value value =
-    Cstruct.of_string value
+  let cstruct_of_value value = Cstruct.of_string value
 
-  let string_of_value value =
-    value
+  let string_of_value value = value
 
   let block_end = P.block_size - sizeof_crc
 
   let _get_block_io () =
     if P.block_size >= Io_page.page_size then
-      Io_page.get_buf ~n:(P.block_size/Io_page.page_size) ()
-    else (* This will only work on Unix, which has buffered IO instead of direct IO.
+      Io_page.get_buf ~n:(P.block_size / Io_page.page_size) ()
+    else
+      (* This will only work on Unix, which has buffered IO instead of direct IO.
             Allows more efficient fuzzing. *)
       Cstruct.create P.block_size
 
   let zero_key = String.make P.key_size '\000'
+
   let top_key = String.make P.key_size '\255'
+
   let zero_data = Cstruct.create P.block_size
-  let _is_zero_data cstr =
-    Cstruct.equal cstr zero_data
+
+  let _is_zero_data cstr = Cstruct.equal cstr zero_data
 
   let childlink_size = P.key_size + sizeof_logical
 
@@ -615,88 +719,101 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
     for i = P.key_size - 1 downto 0 do
       let code = (!state + Char.code key.[i]) mod 256 in
       Bytes.set r i @@ Char.chr code;
-      state := if code = 0 then 1 else 0;
+      state := if code = 0 then 1 else 0
     done;
     Bytes.to_string r
 
   type filesystem = {
     (* Backing device *)
-    disk: B.t;
+    disk : B.t;
     (* The exact size of IO the BLOCK accepts.
      * Even larger powers of two won't work *)
     (* 4096 with unbuffered target=unix, 512 with virtualisation *)
-    sector_size: int;
+    sector_size : int;
     (* the sector size that's used for read/write offsets *)
-    other_sector_size: int;
-    mount_options: mount_options;
+    other_sector_size : int;
+    mount_options : mount_options
   }
 
   type open_fs = {
-    filesystem: filesystem;
-    node_cache: node_cache;
+    filesystem : filesystem;
+    node_cache : node_cache
   }
 
   type root = {
-    open_fs: open_fs;
-    root_key: LRUKey.t;
+    open_fs : open_fs;
+    root_key : LRUKey.t
   }
 
   let is_tombstone root value =
-    root.open_fs.filesystem.mount_options.has_tombstone && String.length value = 0
+    root.open_fs.filesystem.mount_options.has_tombstone
+    && String.length value = 0
 
   let _load_data_at filesystem logical =
     Logs.debug (fun m -> m "_load_data_at %Ld" logical);
     let cstr = _get_block_io () in
     let io_data = make_fanned_io_list filesystem.sector_size cstr in
-    B.read filesystem.disk Int64.(div (mul logical @@ of_int P.block_size) @@ of_int filesystem.other_sector_size) io_data >>= Lwt.wrap1 begin function
-      |Result.Error _ -> raise ReadError
-      |Result.Ok () ->
-          if not @@ Wodan_crc32c.cstruct_valid cstr
-          then raise @@ BadCRC logical
-          else cstr, io_data end
+    B.read filesystem.disk
+      Int64.(
+        div (mul logical @@ of_int P.block_size)
+        @@ of_int filesystem.other_sector_size)
+      io_data
+    >>= Lwt.wrap1 (function
+          | Result.Error _ ->
+              raise ReadError
+          | Result.Ok () ->
+              if not @@ Wodan_crc32c.cstruct_valid cstr then
+                raise @@ BadCRC logical
+              else (cstr, io_data) )
 
   let _find_childlinks_offset cstr value_end =
     let rec scan off poff =
-        if off < value_end then poff else
+      if off < value_end then poff
+      else
         let log1 = Cstruct.LE.get_uint64 cstr (off + P.key_size) in
         if log1 <> 0L then scan (off - childlink_size) off else poff
-    in scan (block_end - childlink_size) block_end
+    in
+    scan (block_end - childlink_size) block_end
 
   (* build a logdata_index *)
   let _index_logdata cstr hdrsize =
     let value_count = Int32.to_int @@ get_anynode_hdr_value_count cstr in
-    Logs.debug (fun m ->
-        m "_index_logdata value_count:%d" value_count);
-    let r = {
-      logdata_contents=KeyedMap.create ();
-      value_end=hdrsize;
-      old_value_end=0;
-    } in
+    Logs.debug (fun m -> m "_index_logdata value_count:%d" value_count);
+    let r =
+      { logdata_contents = KeyedMap.create ();
+        value_end = hdrsize;
+        old_value_end = 0 }
+    in
     let rec scan off value_count =
-      if value_count <= 0 then () else begin
+      if value_count <= 0 then ()
+      else
         let key = Cstruct.to_string @@ Cstruct.sub cstr off P.key_size in
         let len = Cstruct.LE.get_uint16 cstr (off + P.key_size) in
-        let va = Cstruct.to_string @@ Cstruct.sub cstr (off + P.key_size + sizeof_datalen) len in
+        let va =
+          Cstruct.to_string
+          @@ Cstruct.sub cstr (off + P.key_size + sizeof_datalen) len
+        in
         KeyedMap.xadd key va r.logdata_contents;
         r.value_end <- off + P.key_size + sizeof_datalen + len;
-        scan r.value_end @@ pred value_count;
-      end
-    in scan hdrsize value_count;
+        scan r.value_end @@ pred value_count
+    in
+    scan hdrsize value_count;
     r.old_value_end <- r.value_end;
     r
 
   let rec _gen_childlink_offsets start =
     if start >= block_end then []
-    else start::(_gen_childlink_offsets @@ start + childlink_size)
+    else start :: (_gen_childlink_offsets @@ (start + childlink_size))
 
   let _compute_children entry =
     Logs.debug (fun m -> m "_compute_children");
     let r = KeyedMap.create () in
-    List.iter (
-      fun off ->
-        let key = Cstruct.to_string @@ Cstruct.sub (
-          entry.raw_node) off P.key_size in
-        KeyedMap.xadd key (Int64.of_int off) r)
+    List.iter
+      (fun off ->
+        let key =
+          Cstruct.to_string @@ Cstruct.sub entry.raw_node off P.key_size
+        in
+        KeyedMap.xadd key (Int64.of_int off) r )
       (_gen_childlink_offsets entry.childlinks.childlinks_offset);
     r
 
@@ -705,119 +822,180 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
     let%lwt cstr, io_data = _load_data_at open_fs.filesystem logical in
     let cache = open_fs.node_cache in
     assert (Cstruct.len cstr = P.block_size);
-      let cached_node, logdata =
+    let cached_node, logdata =
       match get_anynode_hdr_nodetype cstr with
-      |1 -> `Root, _index_logdata cstr sizeof_rootnode_hdr
-      |ty -> raise @@ BadNodeType ty
+      | 1 ->
+          (`Root, _index_logdata cstr sizeof_rootnode_hdr)
+      | ty ->
+          raise @@ BadNodeType ty
     in
     let alloc_id = next_alloc_id cache in
     let rdepth = get_rootnode_hdr_depth cstr in
-    let rec entry = {parent_key=None; cached_node; raw_node=cstr; rdepth; io_data; logdata; flush_info=None; children=lazy (_compute_children entry); children_alloc_ids=KeyedMap.create (); highest_key=top_key; prev_logical=Some logical; childlinks={childlinks_offset=_find_childlinks_offset cstr logdata.value_end;}} in
-      lru_xset cache.lru alloc_id entry;
-      Lwt.return (alloc_id, entry)
+    let rec entry =
+      { parent_key = None;
+        cached_node;
+        raw_node = cstr;
+        rdepth;
+        io_data;
+        logdata;
+        flush_info = None;
+        children = lazy (_compute_children entry);
+        children_alloc_ids = KeyedMap.create ();
+        highest_key = top_key;
+        prev_logical = Some logical;
+        childlinks =
+          {childlinks_offset = _find_childlinks_offset cstr logdata.value_end}
+      }
+    in
+    lru_xset cache.lru alloc_id entry;
+    Lwt.return (alloc_id, entry)
 
   let _load_child_node_at open_fs logical highest_key parent_key rdepth =
     Logs.debug (fun m -> m "_load_child_node_at");
     let%lwt cstr, io_data = _load_data_at open_fs.filesystem logical in
     let cache = open_fs.node_cache in
     assert (Cstruct.len cstr = P.block_size);
-      let cached_node, logdata =
+    let cached_node, logdata =
       match get_anynode_hdr_nodetype cstr with
-      |2 -> `Child, _index_logdata cstr sizeof_childnode_hdr
-      |ty -> raise @@ BadNodeType ty
+      | 2 ->
+          (`Child, _index_logdata cstr sizeof_childnode_hdr)
+      | ty ->
+          raise @@ BadNodeType ty
     in
-      let alloc_id = next_alloc_id cache in
-    let rec entry = {parent_key=Some parent_key; cached_node; raw_node=cstr; rdepth; io_data; logdata; flush_info=None; children=lazy (_compute_children entry); children_alloc_ids=KeyedMap.create (); highest_key; prev_logical=Some logical; childlinks={childlinks_offset=_find_childlinks_offset cstr logdata.value_end;}} in
-      lru_xset cache.lru alloc_id entry;
-      Lwt.return entry
+    let alloc_id = next_alloc_id cache in
+    let rec entry =
+      { parent_key = Some parent_key;
+        cached_node;
+        raw_node = cstr;
+        rdepth;
+        io_data;
+        logdata;
+        flush_info = None;
+        children = lazy (_compute_children entry);
+        children_alloc_ids = KeyedMap.create ();
+        highest_key;
+        prev_logical = Some logical;
+        childlinks =
+          {childlinks_offset = _find_childlinks_offset cstr logdata.value_end}
+      }
+    in
+    lru_xset cache.lru alloc_id entry;
+    Lwt.return entry
 
-  let _has_children entry =
-    entry.childlinks.childlinks_offset <> block_end
+  let _has_children entry = entry.childlinks.childlinks_offset <> block_end
 
   let has_free_space entry space =
     match space with
-    |InsSpaceChild size ->
-        let refsize = entry.childlinks.childlinks_offset - P.block_size / 2 in
+    | InsSpaceChild size ->
+        let refsize =
+          entry.childlinks.childlinks_offset - (P.block_size / 2)
+        in
         refsize >= size
-    |InsSpaceValue size ->
-        let refsize = if _has_children entry then
-          P.block_size / 2 - entry.logdata.value_end
-        else
-          block_end - entry.logdata.value_end
+    | InsSpaceValue size ->
+        let refsize =
+          if _has_children entry then
+            (P.block_size / 2) - entry.logdata.value_end
+          else block_end - entry.logdata.value_end
         in
         refsize >= size
 
   let _write_node open_fs alloc_id =
     let cache = open_fs.node_cache in
     match lru_get cache.lru alloc_id with
-    |None -> failwith "missing lru entry in _write_node"
-    |Some entry ->
-    let gen = next_generation open_fs.node_cache in
-    set_anynode_hdr_generation entry.raw_node gen;
-    set_anynode_hdr_value_count entry.raw_node @@ Int32.of_int
-    @@ KeyedMap.length entry.logdata.logdata_contents;
-    let logical = next_logical_alloc_valid cache in
-    Logs.debug (fun m -> m "_write_node logical:%Ld gen:%Ld vlen:%d value_end:%d" logical gen (KeyedMap.length entry.logdata.logdata_contents) entry.logdata.value_end);
-    begin match lookup_parent_link cache.lru entry with
-    |Some (parent_key, parent_entry, offset) ->
-      assert (parent_key <> alloc_id);
-      Cstruct.LE.set_uint64 parent_entry.raw_node ((Int64.to_int offset) + P.key_size) logical;
-    |None -> () end;
-    if entry.rdepth = 0l then begin
-      match cache.scan_map with
-      |None -> ()
-      |Some scan_map -> bitv_set64 scan_map logical true
-    end;
-    let offset = ref @@ header_size entry.cached_node in
-    (* XXX Writes in sorted order *)
-    KeyedMap.iter (fun key va ->
-        let len = String.length va in
-        let len1 = len + P.key_size + sizeof_datalen in
-        Cstruct.blit_from_string key 0 entry.raw_node !offset P.key_size;
-        Cstruct.LE.set_uint16 entry.raw_node (!offset + P.key_size) len;
-        Cstruct.blit_from_string va 0 entry.raw_node (!offset + P.key_size + sizeof_datalen) len;
-        offset := !offset + len1;
-      ) entry.logdata.logdata_contents;
-    begin if entry.logdata.value_end < entry.logdata.old_value_end then
-      let len = entry.logdata.old_value_end - entry.logdata.value_end in
-      Cstruct.blit (Cstruct.create len) 0 entry.raw_node entry.logdata.value_end len
-    end;
-    entry.logdata.old_value_end <- entry.logdata.value_end;
-    Wodan_crc32c.cstruct_reset entry.raw_node;
-    begin match entry.prev_logical with
-    |Some plog ->
-        begin
-          Logs.debug (fun m -> m "Decreasing dirty_count");
-          cache.dirty_count <- int64_pred_nowrap cache.dirty_count;
-          bitv_set64 cache.space_map plog false;
-          cache.freed_intervals <- BlockIntervals.add (BlockIntervals.Interval.make plog plog) cache.freed_intervals;
-        end
-    |None ->
-        begin
-          Logs.debug (fun m -> m "Decreasing free_count");
-          cache.free_count <- int64_pred_nowrap cache.free_count;
-          Logs.debug (fun m -> m "Decreasing new_count from %Ld" cache.new_count);
-          cache.new_count <- int64_pred_nowrap cache.new_count; (* XXX BUG sometimes wraps *)
-        end;
-      end;
-    bitv_set64 cache.space_map logical true;
-    cache.freed_intervals <- BlockIntervals.remove (BlockIntervals.Interval.make logical logical) cache.freed_intervals;
-    entry.prev_logical <- Some logical;
-    B.write open_fs.filesystem.disk
-        Int64.(div (mul logical @@ of_int P.block_size) @@ of_int open_fs.filesystem.other_sector_size) entry.io_data >>= function
-      |Result.Ok () -> Lwt.return ()
-      |Result.Error _ -> Lwt.fail WriteError
+    | None ->
+        failwith "missing lru entry in _write_node"
+    | Some entry -> (
+        let gen = next_generation open_fs.node_cache in
+        set_anynode_hdr_generation entry.raw_node gen;
+        set_anynode_hdr_value_count entry.raw_node
+        @@ Int32.of_int
+        @@ KeyedMap.length entry.logdata.logdata_contents;
+        let logical = next_logical_alloc_valid cache in
+        Logs.debug (fun m ->
+            m "_write_node logical:%Ld gen:%Ld vlen:%d value_end:%d" logical
+              gen
+              (KeyedMap.length entry.logdata.logdata_contents)
+              entry.logdata.value_end );
+        ( match lookup_parent_link cache.lru entry with
+        | Some (parent_key, parent_entry, offset) ->
+            assert (parent_key <> alloc_id);
+            Cstruct.LE.set_uint64 parent_entry.raw_node
+              (Int64.to_int offset + P.key_size)
+              logical
+        | None ->
+            () );
+        ( if entry.rdepth = 0l then
+          match cache.scan_map with
+          | None ->
+              ()
+          | Some scan_map ->
+              bitv_set64 scan_map logical true );
+        let offset = ref @@ header_size entry.cached_node in
+        (* XXX Writes in sorted order *)
+        KeyedMap.iter
+          (fun key va ->
+            let len = String.length va in
+            let len1 = len + P.key_size + sizeof_datalen in
+            Cstruct.blit_from_string key 0 entry.raw_node !offset P.key_size;
+            Cstruct.LE.set_uint16 entry.raw_node (!offset + P.key_size) len;
+            Cstruct.blit_from_string va 0 entry.raw_node
+              (!offset + P.key_size + sizeof_datalen)
+              len;
+            offset := !offset + len1 )
+          entry.logdata.logdata_contents;
+        ( if entry.logdata.value_end < entry.logdata.old_value_end then
+          let len = entry.logdata.old_value_end - entry.logdata.value_end in
+          Cstruct.blit (Cstruct.create len) 0 entry.raw_node
+            entry.logdata.value_end len );
+        (entry.logdata).old_value_end <- entry.logdata.value_end;
+        Wodan_crc32c.cstruct_reset entry.raw_node;
+        ( match entry.prev_logical with
+        | Some plog ->
+            Logs.debug (fun m -> m "Decreasing dirty_count");
+            cache.dirty_count <- int64_pred_nowrap cache.dirty_count;
+            bitv_set64 cache.space_map plog false;
+            cache.freed_intervals
+            <- BlockIntervals.add
+                 (BlockIntervals.Interval.make plog plog)
+                 cache.freed_intervals
+        | None ->
+            Logs.debug (fun m -> m "Decreasing free_count");
+            cache.free_count <- int64_pred_nowrap cache.free_count;
+            Logs.debug (fun m ->
+                m "Decreasing new_count from %Ld" cache.new_count );
+            cache.new_count <- int64_pred_nowrap cache.new_count
+            (* XXX BUG sometimes wraps *) );
+        bitv_set64 cache.space_map logical true;
+        cache.freed_intervals
+        <- BlockIntervals.remove
+             (BlockIntervals.Interval.make logical logical)
+             cache.freed_intervals;
+        entry.prev_logical <- Some logical;
+        B.write open_fs.filesystem.disk
+          Int64.(
+            div (mul logical @@ of_int P.block_size)
+            @@ of_int open_fs.filesystem.other_sector_size)
+          entry.io_data
+        >>= function
+        | Result.Ok () ->
+            Lwt.return ()
+        | Result.Error _ ->
+            Lwt.fail WriteError )
 
   let _log_statistics cache =
     let stats = cache.statistics in
-    Logs.info (fun m -> m "Ops: %d inserts %d lookups" stats.inserts stats.lookups);
+    Logs.info (fun m ->
+        m "Ops: %d inserts %d lookups" stats.inserts stats.lookups );
     let logical_size = bitv_len64 cache.space_map in
     (* Don't count the superblock as a node *)
     Logs.debug (fun m -> m "Decreasing free_count to log stats");
-    let nstored = int64_pred_nowrap @@ Int64.sub logical_size cache.free_count in
+    let nstored =
+      int64_pred_nowrap @@ Int64.sub logical_size cache.free_count
+    in
     let ndirty = cache.dirty_count in
     let nnew = cache.new_count in
-    Logs.info (fun m -> m "Nodes: %Ld on-disk (%Ld dirty), %Ld new" nstored ndirty nnew);
+    Logs.info (fun m ->
+        m "Nodes: %Ld on-disk (%Ld dirty), %Ld new" nstored ndirty nnew );
     Logs.info (fun m -> m "LRU: %d" (LRU.items cache.lru));
     ()
 
@@ -828,31 +1006,51 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
   let flush root =
     let open_fs = root.open_fs in
     let cache = open_fs.node_cache in
-    Logs.info (fun m -> m "Flushing %d dirty roots" (match cache.flush_root with None -> 0 |Some _ -> 1));
+    Logs.info (fun m ->
+        m "Flushing %d dirty roots"
+          ( match cache.flush_root with
+          | None ->
+              0
+          | Some _ ->
+              1 ) );
     _log_statistics cache;
-    if Int64.(compare cache.free_count @@ add cache.new_count cache.dirty_count) < 0 then failwith "Out of space";
-    let rec flush_rec parent_key _key alloc_id (completion_list : unit Lwt.t list) = begin
-      if alloc_id = parent_key then begin
-        Logs.err (fun m -> m "Reference loop in flush_children at %Ld" alloc_id);
-        failwith "Reference loop";
-      end;
+    if
+      Int64.(
+        compare cache.free_count @@ add cache.new_count cache.dirty_count)
+      < 0
+    then failwith "Out of space";
+    let rec flush_rec parent_key _key alloc_id
+        (completion_list : unit Lwt.t list) =
+      if alloc_id = parent_key then (
+        Logs.err (fun m ->
+            m "Reference loop in flush_children at %Ld" alloc_id );
+        failwith "Reference loop" );
       match lru_get cache.lru alloc_id with
-      |None -> failwith "missing alloc_id"
-      |Some entry ->
-          Logs.debug (fun m -> m "collecting %Ld parent %Ld" alloc_id parent_key);
-        match entry.flush_info with
-        (* Can happen with a diamond pattern *)
-        |None -> failwith "Flushed but missing flush_info"
-        |Some di ->
-      let completion_list = KeyedMap.fold (flush_rec alloc_id) di.flush_children completion_list in
-      entry.flush_info <- None;
-      (_write_node open_fs alloc_id) :: completion_list
-    end in
-    let r = Lwt.join (match cache.flush_root with
-        |None -> []
-        |Some alloc_id ->
-            flush_rec 0L zero_key alloc_id []
-      ) in
+      | None ->
+          failwith "missing alloc_id"
+      | Some entry -> (
+          Logs.debug (fun m ->
+              m "collecting %Ld parent %Ld" alloc_id parent_key );
+          match entry.flush_info with
+          (* Can happen with a diamond pattern *)
+          | None ->
+              failwith "Flushed but missing flush_info"
+          | Some di ->
+              let completion_list =
+                KeyedMap.fold (flush_rec alloc_id) di.flush_children
+                  completion_list
+              in
+              entry.flush_info <- None;
+              _write_node open_fs alloc_id :: completion_list )
+    in
+    let r =
+      Lwt.join
+        ( match cache.flush_root with
+        | None ->
+            []
+        | Some alloc_id ->
+            flush_rec 0L zero_key alloc_id [] )
+    in
     cache.flush_root <- None;
     assert (cache.new_count = 0L);
     assert (cache.dirty_count = 0L);
@@ -860,10 +1058,15 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
 
   let _discard_block_range open_fs logical n =
     B.discard open_fs.filesystem.disk
-      Int64.(div (mul logical @@ of_int P.block_size) @@ of_int open_fs.filesystem.other_sector_size)
-      Int64.(div (mul n @@ of_int P.block_size) @@ of_int open_fs.filesystem.other_sector_size)
-    >|= function res ->
-      Rresult.R.get_ok res
+      Int64.(
+        div (mul logical @@ of_int P.block_size)
+        @@ of_int open_fs.filesystem.other_sector_size)
+      Int64.(
+        div (mul n @@ of_int P.block_size)
+        @@ of_int open_fs.filesystem.other_sector_size)
+    >|= function
+    | res ->
+        Rresult.R.get_ok res
 
   let fstrim root =
     let open_fs = root.open_fs in
@@ -871,47 +1074,50 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
     let discard_count = ref 0L in
     let unused_start = ref None in
     let to_discard = ref [] in
-    Bitv.iteri (fun i used ->
-        match !unused_start, used with
-        |None, false ->
-          unused_start := Some(i)
-        |Some(start), true -> begin
-            let range_block_count = Int64.of_int @@ i - start in
+    Bitv.iteri
+      (fun i used ->
+        match (!unused_start, used) with
+        | None, false ->
+            unused_start := Some i
+        | Some start, true ->
+            let range_block_count = Int64.of_int @@ (i - start) in
             to_discard := (start, range_block_count) :: !to_discard;
             discard_count := Int64.add !discard_count range_block_count;
             unused_start := None
-          end
-        |_ -> ()
-      ) cache.space_map;
-    begin
-      match !unused_start with
-      |Some(start) ->
-        let range_block_count = Int64.sub
-            cache.logical_size @@ Int64.of_int start in
+        | _ ->
+            () )
+      cache.space_map;
+    ( match !unused_start with
+    | Some start ->
+        let range_block_count =
+          Int64.sub cache.logical_size @@ Int64.of_int start
+        in
         to_discard := (start, range_block_count) :: !to_discard
-      |_ -> ()
-    end;
-    Lwt_list.iter_s (fun (start, range_block_count) ->
-        _discard_block_range open_fs (Int64.of_int start) range_block_count
-      ) !to_discard
+    | _ ->
+        () );
+    Lwt_list.iter_s
+      (fun (start, range_block_count) ->
+        _discard_block_range open_fs (Int64.of_int start) range_block_count )
+      !to_discard
     >|= fun () -> !discard_count
 
-(* Discard blocks that have been unused since mounting
+  (* Discard blocks that have been unused since mounting
    or since the last live_trim call *)
   let live_trim root =
     let discard_count = ref 0L in
     let to_discard = ref [] in
-    BlockIntervals.iter (
-      fun iv ->
+    BlockIntervals.iter
+      (fun iv ->
         let start = BlockIntervals.Interval.x iv in
         let exclend = Int64.succ @@ BlockIntervals.Interval.y iv in
         let range_block_count = Int64.sub exclend start in
         discard_count := Int64.add !discard_count range_block_count;
-        to_discard := (start, range_block_count) :: !to_discard
-    ) root.open_fs.node_cache.freed_intervals;
-    Lwt_list.iter_s (fun (start, range_block_count) ->
-        _discard_block_range root.open_fs start range_block_count
-      ) !to_discard
+        to_discard := (start, range_block_count) :: !to_discard )
+      root.open_fs.node_cache.freed_intervals;
+    Lwt_list.iter_s
+      (fun (start, range_block_count) ->
+        _discard_block_range root.open_fs start range_block_count )
+      !to_discard
     >|= fun () -> !discard_count
 
   let _new_node open_fs tycode parent_key highest_key rdepth =
@@ -923,29 +1129,46 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
     set_anynode_hdr_nodetype cstr tycode;
     set_anynode_hdr_fsid cache.fsid 0 cstr;
     let io_data = make_fanned_io_list open_fs.filesystem.sector_size cstr in
-    let cached_node = match tycode with
-    |1 -> `Root
-    |2 -> `Child
-    |ty -> raise @@ BadNodeType ty
+    let cached_node =
+      match tycode with
+      | 1 ->
+          `Root
+      | 2 ->
+          `Child
+      | ty ->
+          raise @@ BadNodeType ty
     in
     let value_end = header_size cached_node in
-      let logdata = {
-        logdata_contents=KeyedMap.create ();
-        value_end; old_value_end=value_end;
-      } in
-    let entry = {parent_key; cached_node; raw_node=cstr; rdepth; io_data; logdata; flush_info=None; children=Lazy.from_val @@ KeyedMap.create (); children_alloc_ids=KeyedMap.create (); highest_key; prev_logical=None; childlinks={childlinks_offset=block_end;}} in
+    let logdata =
+      { logdata_contents = KeyedMap.create ();
+        value_end;
+        old_value_end = value_end }
+    in
+    let entry =
+      { parent_key;
+        cached_node;
+        raw_node = cstr;
+        rdepth;
+        io_data;
+        logdata;
+        flush_info = None;
+        children = Lazy.from_val @@ KeyedMap.create ();
+        children_alloc_ids = KeyedMap.create ();
+        highest_key;
+        prev_logical = None;
+        childlinks = {childlinks_offset = block_end} }
+    in
     lru_xset cache.lru alloc_id entry;
-    alloc_id, entry
+    (alloc_id, entry)
 
-  let _new_root open_fs =
-    _new_node open_fs 1 None top_key 0l
+  let _new_root open_fs = _new_node open_fs 1 None top_key 0l
 
   let _reset_contents entry =
     let hdrsize = header_size entry.cached_node in
-    entry.logdata.value_end <- hdrsize;
-    entry.logdata.old_value_end <- hdrsize;
-    entry.logdata.logdata_contents <- KeyedMap.create ();
-    entry.childlinks.childlinks_offset <- block_end;
+    (entry.logdata).value_end <- hdrsize;
+    (entry.logdata).old_value_end <- hdrsize;
+    (entry.logdata).logdata_contents <- KeyedMap.create ();
+    (entry.childlinks).childlinks_offset <- block_end;
     entry.children <- Lazy.from_val (KeyedMap.create ());
     entry.children_alloc_ids <- KeyedMap.create ();
     Cstruct.blit zero_data 0 entry.raw_node hdrsize (block_end - hdrsize)
@@ -954,12 +1177,19 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
     Logs.debug (fun m -> m "_add_child");
     let child_key = alloc_id in
     let off = parent.childlinks.childlinks_offset - childlink_size in
-    let children = Lazy.force parent.children in (* Force *before* blitting *)
+    let children = Lazy.force parent.children in
+    (* Force *before* blitting *)
     child.parent_key <- Some parent_key;
-    Cstruct.blit (Cstruct.of_string child.highest_key) 0 parent.raw_node off P.key_size;
-    parent.childlinks.childlinks_offset <- off;
-    KeyedMap.xadd (Cstruct.to_string @@ Cstruct.sub parent.raw_node off P.key_size) (Int64.of_int off) children;
-    KeyedMap.xadd (Cstruct.to_string @@ Cstruct.sub parent.raw_node off P.key_size) alloc_id parent.children_alloc_ids;
+    Cstruct.blit
+      (Cstruct.of_string child.highest_key)
+      0 parent.raw_node off P.key_size;
+    (parent.childlinks).childlinks_offset <- off;
+    KeyedMap.xadd
+      (Cstruct.to_string @@ Cstruct.sub parent.raw_node off P.key_size)
+      (Int64.of_int off) children;
+    KeyedMap.xadd
+      (Cstruct.to_string @@ Cstruct.sub parent.raw_node off P.key_size)
+      alloc_id parent.children_alloc_ids;
     (*ignore @@ _mark_dirty cache parent_key;*)
     ignore @@ _mark_dirty cache child_key
 
@@ -968,31 +1198,43 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
 
   let _update_space_map cache logical expect_sm =
     let sm = bitv_get64 cache.space_map logical in
-    if sm <> expect_sm then if expect_sm then failwith "logical address appeared out of thin air" else failwith "logical address referenced twice";
-    if not expect_sm then begin
+    if sm <> expect_sm then
+      if expect_sm then failwith "logical address appeared out of thin air"
+      else failwith "logical address referenced twice";
+    if not expect_sm then (
       bitv_set64 cache.space_map logical true;
-      cache.free_count <- int64_pred_nowrap cache.free_count
-    end
+      cache.free_count <- int64_pred_nowrap cache.free_count )
 
-  let rec _scan_all_nodes open_fs logical expect_root rdepth parent_gen expect_sm =
+  let rec _scan_all_nodes open_fs logical expect_root rdepth parent_gen
+      expect_sm =
     Logs.debug (fun m -> m "_scan_all_nodes %Ld %ld" logical rdepth);
     (* TODO add more fsck style checks *)
     let cache = open_fs.node_cache in
     _update_space_map cache logical expect_sm;
     let%lwt cstr, _io_data = _load_data_at open_fs.filesystem logical in
-    let hdrsize = match get_anynode_hdr_nodetype cstr with
-      |1 (* root *) when expect_root -> sizeof_rootnode_hdr
-      |2 (* inner *) when not expect_root -> sizeof_childnode_hdr
-      |ty -> raise @@ BadNodeType ty
+    let hdrsize =
+      match get_anynode_hdr_nodetype cstr with
+      | 1
+      (* root *)
+        when expect_root ->
+          sizeof_rootnode_hdr
+      | 2
+      (* inner *)
+        when not expect_root ->
+          sizeof_childnode_hdr
+      | ty ->
+          raise @@ BadNodeType ty
     in
     let fsid = Cstruct.to_string @@ get_anynode_hdr_fsid cstr in
     if fsid <> cache.fsid then raise (BadNodeFSID fsid);
     let gen = get_anynode_hdr_generation cstr in
     (* prevents cycles *)
-    if gen >= parent_gen then failwith "generation is not lower than for parent";
+    if gen >= parent_gen then
+      failwith "generation is not lower than for parent";
     let value_count = Int32.to_int @@ get_anynode_hdr_value_count cstr in
     let rec scan_kd off value_count =
-      if value_count <= 0 then off else begin
+      if value_count <= 0 then off
+      else
         let off1 = off + P.key_size + sizeof_datalen in
         if off1 > block_end then failwith "data bleeding past end of node";
         (* TODO check for key unicity in scan_kd and scan_cl *)
@@ -1002,240 +1244,310 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
         let off2 = off + len1 in
         if off2 > block_end then failwith "data bleeding past end of node";
         scan_kd off2 @@ pred value_count
-      end
     in
     let value_end = scan_kd hdrsize value_count in
     let rec scan_cl off =
-      if off < hdrsize then failwith "child link data bleeding into start of node";
-      if off >= value_end then begin
+      if off < hdrsize then
+        failwith "child link data bleeding into start of node";
+      if off >= value_end then
         let log1 = Cstruct.LE.get_uint64 cstr (off + P.key_size) in
-        begin if log1 <> 0L then begin
+        if log1 <> 0L then (
           (* Children here would mean the fast_scan free space map is borked *)
           if rdepth = 0l then failwith "Found children on a leaf node";
-          begin if rdepth = 1l && open_fs.filesystem.mount_options.fast_scan then begin
+          ( if rdepth = 1l && open_fs.filesystem.mount_options.fast_scan then (
             _update_space_map cache log1 false;
-            Lwt.return_unit
-          end else
+            Lwt.return_unit )
+          else
             _scan_all_nodes open_fs log1 false (Int32.pred rdepth) gen false
-          end >>= fun () -> scan_cl (off - childlink_size)
-          end
-          else Lwt.return_unit
-        end
-      end
+          )
+          >>= fun () -> scan_cl (off - childlink_size) )
+        else Lwt.return_unit
       else Lwt.return_unit
     in
-    scan_cl (block_end - childlink_size) >>= fun () ->
-    begin
-      if rdepth = 0l then begin
+    scan_cl (block_end - childlink_size)
+    >>= fun () ->
+    ( if rdepth = 0l then
       match cache.scan_map with
-        |None -> ()
-        |Some scan_map -> bitv_set64 scan_map logical true;
-      end;
-      Lwt.return_unit
-    end
+      | None ->
+          ()
+      | Some scan_map ->
+          bitv_set64 scan_map logical true );
+    Lwt.return_unit
 
   let _logical_of_offset cstr offset =
-    Cstruct.LE.get_uint64 cstr ((Int64.to_int offset) + P.key_size)
+    Cstruct.LE.get_uint64 cstr (Int64.to_int offset + P.key_size)
 
   let _preload_child open_fs entry_key entry child_key offset =
     (*Logs.debug (fun m -> m "_preload_child");*)
     let cstr = entry.raw_node in
     let cache = open_fs.node_cache in
-    if entry.rdepth = 0l then failwith "invalid rdepth: found children when rdepth = 0";
+    if entry.rdepth = 0l then
+      failwith "invalid rdepth: found children when rdepth = 0";
     let rdepth = Int32.pred entry.rdepth in
     match KeyedMap.find_opt child_key entry.children_alloc_ids with
-    |None ->
+    | None ->
         let logical = _logical_of_offset cstr offset in
-        begin if%lwt Lwt.return open_fs.filesystem.mount_options.fast_scan then match cache.scan_map with None -> assert false |Some scan_map ->
-          if%lwt Lwt.return (rdepth = 0l && not @@ bitv_get64 scan_map logical) then
-            (* generation may not be fresh, but is always initialised in this branch,
+        ( if%lwt Lwt.return open_fs.filesystem.mount_options.fast_scan then
+          match cache.scan_map with
+          | None ->
+              assert false
+          | Some scan_map ->
+              if%lwt
+                Lwt.return
+                  (rdepth = 0l && (not @@ bitv_get64 scan_map logical))
+              then
+                (* generation may not be fresh, but is always initialised in this branch,
                so this is not a problem *)
-            let parent_gen = get_anynode_hdr_generation cstr in
-            _scan_all_nodes open_fs logical false rdepth parent_gen true end
+                let parent_gen = get_anynode_hdr_generation cstr in
+                _scan_all_nodes open_fs logical false rdepth parent_gen true
+        )
         >>= fun () ->
-        let%lwt child_entry = _load_child_node_at open_fs logical child_key entry_key rdepth in
+        let%lwt child_entry =
+          _load_child_node_at open_fs logical child_key entry_key rdepth
+        in
         let alloc_id = next_alloc_id cache in
         KeyedMap.xadd child_key alloc_id entry.children_alloc_ids;
         lru_xset cache.lru alloc_id child_entry;
         Lwt.return (alloc_id, child_entry)
-    |Some alloc_id ->
+    | Some alloc_id -> (
       match lru_get cache.lru alloc_id with
-      |None -> Lwt.fail @@ Failure (Printf.sprintf "Missing LRU entry for loaded child %Ld %Ld" offset alloc_id)
-      |Some child_entry ->
-        Lwt.return (alloc_id, child_entry)
+      | None ->
+          Lwt.fail
+          @@ Failure
+               (Printf.sprintf "Missing LRU entry for loaded child %Ld %Ld"
+                  offset alloc_id)
+      | Some child_entry ->
+          Lwt.return (alloc_id, child_entry) )
 
   let _ins_req_space = function
-    |InsValue value ->
+    | InsValue value ->
         let len = String.length value in
         let len1 = P.key_size + sizeof_datalen + len in
         InsSpaceValue len1
-    |InsChild (_loc, _alloc_id) ->
+    | InsChild (_loc, _alloc_id) ->
         InsSpaceChild (P.key_size + sizeof_logical)
 
   let _fast_insert fs alloc_id key insertable _depth =
     (*Logs.debug (fun m -> m "_fast_insert %Ld" _depth);*)
     match lru_get fs.node_cache.lru alloc_id with
-    |None -> failwith @@ Printf.sprintf "Missing LRU entry for %Ld (_fast_insert)" alloc_id
-    |Some entry ->
-    assert (String.compare key entry.highest_key <= 0);
-    begin
-      assert (has_free_space entry @@ _ins_req_space insertable);
-      begin (* Simple insertion *)
+    | None ->
+        failwith
+        @@ Printf.sprintf "Missing LRU entry for %Ld (_fast_insert)" alloc_id
+    | Some entry -> (
+        assert (String.compare key entry.highest_key <= 0);
+        assert (has_free_space entry @@ _ins_req_space insertable);
+        (* Simple insertion *)
         match insertable with
-        |InsValue value ->
-          let len = String.length value in
-          let len1 = P.key_size + sizeof_datalen + len in
-          let kd = entry.logdata in
-          (* TODO optionally optimize storing tombstones on leaf nodes *)
-          KeyedMap.map1 key (function
-              |None ->
-              (* Padded length *)
-              kd.value_end <- kd.value_end + len1;
-              Some value
-            |Some prev_val ->
-              (* No need to pad lengths *)
-              kd.value_end <- kd.value_end - (String.length prev_val) + len;
-              Some value
-            ) kd.logdata_contents;
-          ignore @@ _mark_dirty fs.node_cache alloc_id;
-        |InsChild (loc, child_alloc_id_opt) ->
-          let cstr = entry.raw_node in
-          let cls = entry.childlinks in
-          let offset = cls.childlinks_offset - childlink_size in
-          let children = Lazy.force entry.children in
-          cls.childlinks_offset <- offset;
-          Cstruct.blit (Cstruct.of_string key) 0 cstr offset P.key_size;
-          Cstruct.LE.set_uint64 cstr (offset + P.key_size) loc;
-          KeyedMap.xadd (Cstruct.to_string @@ Cstruct.sub cstr offset P.key_size) (Int64.of_int offset) children;
-          begin match child_alloc_id_opt with
-          |None -> ()
-          |Some child_alloc_id -> KeyedMap.xadd (Cstruct.to_string @@ Cstruct.sub cstr offset P.key_size) child_alloc_id entry.children_alloc_ids
-          end;
-          ignore @@ _mark_dirty fs.node_cache alloc_id;
-      end
-    end
+        | InsValue value ->
+            let len = String.length value in
+            let len1 = P.key_size + sizeof_datalen + len in
+            let kd = entry.logdata in
+            (* TODO optionally optimize storing tombstones on leaf nodes *)
+            KeyedMap.map1 key
+              (function
+                | None ->
+                    (* Padded length *)
+                    kd.value_end <- kd.value_end + len1;
+                    Some value
+                | Some prev_val ->
+                    (* No need to pad lengths *)
+                    kd.value_end
+                    <- kd.value_end - String.length prev_val + len;
+                    Some value)
+              kd.logdata_contents;
+            ignore @@ _mark_dirty fs.node_cache alloc_id
+        | InsChild (loc, child_alloc_id_opt) ->
+            let cstr = entry.raw_node in
+            let cls = entry.childlinks in
+            let offset = cls.childlinks_offset - childlink_size in
+            let children = Lazy.force entry.children in
+            cls.childlinks_offset <- offset;
+            Cstruct.blit (Cstruct.of_string key) 0 cstr offset P.key_size;
+            Cstruct.LE.set_uint64 cstr (offset + P.key_size) loc;
+            KeyedMap.xadd
+              (Cstruct.to_string @@ Cstruct.sub cstr offset P.key_size)
+              (Int64.of_int offset) children;
+            ( match child_alloc_id_opt with
+            | None ->
+                ()
+            | Some child_alloc_id ->
+                KeyedMap.xadd
+                  (Cstruct.to_string @@ Cstruct.sub cstr offset P.key_size)
+                  child_alloc_id entry.children_alloc_ids );
+            ignore @@ _mark_dirty fs.node_cache alloc_id )
 
   let _split_point entry =
     if _has_children entry then
       let children = Lazy.force entry.children in
       let n = KeyedMap.length children in
       let binds = keyedmap_keys children in
-      let median = List.nth binds @@ n/2 in
+      let median = List.nth binds @@ (n / 2) in
       median
     else
       let kdc = entry.logdata.logdata_contents in
       let n = KeyedMap.length kdc in
       let binds = keyedmap_keys kdc in
-      let median = List.nth binds @@ n/2 in
+      let median = List.nth binds @@ (n / 2) in
       median
 
   let rec _check_live_integrity fs alloc_id depth =
     let fail = ref false in
     match lru_peek fs.node_cache.lru alloc_id with
-    |None -> failwith "Missing LRU entry"
-    |Some entry -> begin
-        if _has_children entry && not (String.equal entry.highest_key @@ fst @@ unwrap_opt @@ KeyedMap.max_binding @@ Lazy.force entry.children) then begin
-          string_dump @@ entry.highest_key;
-          string_dump @@ fst @@ unwrap_opt @@ KeyedMap.max_binding @@ Lazy.force entry.children;
-          Logs.err (fun m -> m "_check_live_integrity %Ld invariant broken: highest_key" depth);
-          fail := true;
-        end;
-        match entry.parent_key with
-        |None -> ()
-        |Some parent_key -> begin
+    | None ->
+        failwith "Missing LRU entry"
+    | Some entry ->
+        ( if
+            _has_children entry
+            && not
+                 ( String.equal entry.highest_key
+                 @@ fst
+                 @@ unwrap_opt
+                 @@ KeyedMap.max_binding
+                 @@ Lazy.force entry.children )
+          then (
+            string_dump @@ entry.highest_key;
+            string_dump
+            @@ fst
+            @@ unwrap_opt
+            @@ KeyedMap.max_binding
+            @@ Lazy.force entry.children;
+            Logs.err (fun m ->
+                m "_check_live_integrity %Ld invariant broken: highest_key"
+                  depth );
+            fail := true );
+          match entry.parent_key with
+          | None ->
+              ()
+          | Some parent_key -> (
             match lru_peek fs.node_cache.lru parent_key with
-            |None -> failwith "Missing parent"
-            |Some parent_entry ->
-              let children = Lazy.force parent_entry.children in
-              match KeyedMap.find_opt entry.highest_key children with
-              |None ->
-                Logs.err (fun m -> m "_check_live_integrity %Ld invariant broken: lookup_parent_link" depth);
-                fail := true;
-              |Some _offset ->
-                assert (KeyedMap.find_opt entry.highest_key parent_entry.children_alloc_ids = Some alloc_id);
-          end;
-      end;
-
-      let vend = ref @@ header_size entry.cached_node in
-      KeyedMap.iter (fun _k va ->
-        vend := !vend + P.key_size + sizeof_datalen + String.length va
-                ) entry.logdata.logdata_contents;
-      if !vend != entry.logdata.value_end then begin
-        Logs.err (fun m -> m "Inconsistent value_end %Ld" depth);
-        fail := true;
-      end;
-
-      begin match entry.flush_info with
-      |Some flush_info -> begin
-          if KeyedMap.exists
-              (fun _k child_alloc_id -> child_alloc_id = alloc_id)
-              flush_info.flush_children then begin
-          Logs.err (fun m -> m "Self-pointing flush reference %Ld" depth);
-          fail := true;
-        end;
-        match entry.parent_key with
-        |None -> ()
-        |Some parent_key ->
-            match lru_peek fs.node_cache.lru parent_key with
-            |None -> failwith "Missing parent"
-            |Some parent_entry ->
+            | None ->
+                failwith "Missing parent"
+            | Some parent_entry -> (
+                let children = Lazy.force parent_entry.children in
+                match KeyedMap.find_opt entry.highest_key children with
+                | None ->
+                    Logs.err (fun m ->
+                        m
+                          "_check_live_integrity %Ld invariant broken: \
+                           lookup_parent_link"
+                          depth );
+                    fail := true
+                | Some _offset ->
+                    assert (
+                      KeyedMap.find_opt entry.highest_key
+                        parent_entry.children_alloc_ids
+                      = Some alloc_id ) ) ) );
+        let vend = ref @@ header_size entry.cached_node in
+        KeyedMap.iter
+          (fun _k va ->
+            vend := !vend + P.key_size + sizeof_datalen + String.length va )
+          entry.logdata.logdata_contents;
+        if !vend != entry.logdata.value_end then (
+          Logs.err (fun m -> m "Inconsistent value_end %Ld" depth);
+          fail := true );
+        ( match entry.flush_info with
+        | Some flush_info -> (
+            if
+              KeyedMap.exists
+                (fun _k child_alloc_id -> child_alloc_id = alloc_id)
+                flush_info.flush_children
+            then (
+              Logs.err (fun m -> m "Self-pointing flush reference %Ld" depth);
+              fail := true );
+            match entry.parent_key with
+            | None ->
+                ()
+            | Some parent_key -> (
+              match lru_peek fs.node_cache.lru parent_key with
+              | None ->
+                  failwith "Missing parent"
+              | Some parent_entry -> (
                 match parent_entry.flush_info with
-                |None -> failwith "Missing parent_entry.flush_info"
-                |Some di -> let n = KeyedMap.fold (fun _k el acc -> if el = alloc_id then succ acc else acc) di.flush_children 0 in
-                if n = 0 then begin
-                  Logs.err (fun m -> m "Dirty but not registered in parent_entry.flush_info %Ld %Ld" depth alloc_id);
-                  fail := true;
-                end else if n > 1 then begin
-                  Logs.err (fun m -> m "Dirty, registered %d times in parent_entry.flush_info %Ld" n depth);
-                  fail := true;
-                end
-      end
-      |None -> begin
-        match entry.parent_key with
-        |None -> ()
-        |Some parent_key ->
+                | None ->
+                    failwith "Missing parent_entry.flush_info"
+                | Some di ->
+                    let n =
+                      KeyedMap.fold
+                        (fun _k el acc ->
+                          if el = alloc_id then succ acc else acc )
+                        di.flush_children 0
+                    in
+                    if n = 0 then (
+                      Logs.err (fun m ->
+                          m
+                            "Dirty but not registered in \
+                             parent_entry.flush_info %Ld %Ld"
+                            depth alloc_id );
+                      fail := true )
+                    else if n > 1 then (
+                      Logs.err (fun m ->
+                          m
+                            "Dirty, registered %d times in \
+                             parent_entry.flush_info %Ld"
+                            n depth );
+                      fail := true ) ) ) )
+        | None -> (
+          match entry.parent_key with
+          | None ->
+              ()
+          | Some parent_key -> (
             match lru_peek fs.node_cache.lru parent_key with
-            |None -> failwith "Missing parent"
-            |Some parent_entry ->
-                match parent_entry.flush_info with
-                |None -> ()
-                |Some di -> if KeyedMap.exists (fun _k el -> el = alloc_id) di.flush_children then begin
-                  Logs.err (fun m -> m "Not dirty but registered in parent_entry.flush_info %Ld" depth);
-                  fail := true;
-                end
-      end;
-      end;
-      KeyedMap.iter (fun k offset ->
-              let cstr = entry.raw_node in
-              let key = Cstruct.to_string @@ Cstruct.sub cstr (Int64.to_int offset) P.key_size in
-              assert (k = key)
-              ) @@ Lazy.force entry.children;
-      KeyedMap.iter (fun _k child_alloc_id ->
-          if child_alloc_id = alloc_id then begin
-            Logs.err (fun m -> m "Self-pointing node %Ld" depth);
-            fail := true;
-          end else
-            _check_live_integrity fs child_alloc_id @@ Int64.succ depth
-        ) entry.children_alloc_ids;
-      if !fail then failwith "Integrity errors"
+            | None ->
+                failwith "Missing parent"
+            | Some parent_entry -> (
+              match parent_entry.flush_info with
+              | None ->
+                  ()
+              | Some di ->
+                  if
+                    KeyedMap.exists
+                      (fun _k el -> el = alloc_id)
+                      di.flush_children
+                  then (
+                    Logs.err (fun m ->
+                        m
+                          "Not dirty but registered in \
+                           parent_entry.flush_info %Ld"
+                          depth );
+                    fail := true ) ) ) ) );
+        KeyedMap.iter (fun k offset ->
+            let cstr = entry.raw_node in
+            let key =
+              Cstruct.to_string
+              @@ Cstruct.sub cstr (Int64.to_int offset) P.key_size
+            in
+            assert (k = key) )
+        @@ Lazy.force entry.children;
+        KeyedMap.iter
+          (fun _k child_alloc_id ->
+            if child_alloc_id = alloc_id then (
+              Logs.err (fun m -> m "Self-pointing node %Ld" depth);
+              fail := true )
+            else _check_live_integrity fs child_alloc_id @@ Int64.succ depth
+            )
+          entry.children_alloc_ids;
+        if !fail then failwith "Integrity errors"
 
   let _check_live_integrity _fs _alloc_id _depth = ()
 
   let _fixup_parent_links cache alloc_id entry =
-    KeyedMap.iter (fun _k child_alloc_id ->
-          match lru_peek cache.lru child_alloc_id with
-          |None -> failwith "Missing LRU entry"
-          |Some centry -> centry.parent_key <- Some alloc_id
-      ) entry.children_alloc_ids
+    KeyedMap.iter
+      (fun _k child_alloc_id ->
+        match lru_peek cache.lru child_alloc_id with
+        | None ->
+            failwith "Missing LRU entry"
+        | Some centry ->
+            centry.parent_key <- Some alloc_id )
+      entry.children_alloc_ids
 
   let _value_at fs va =
     let len = String.length va in
-    if fs.mount_options.has_tombstone && len = 0 then None else
-    Some va
+    if fs.mount_options.has_tombstone && len = 0 then None else Some va
 
   let _is_value fs va =
     if not fs.mount_options.has_tombstone then true
-    else let len = String.length va in
+    else
+      let len = String.length va in
       len <> 0
 
   (* lwt because it might load from disk *)
@@ -1243,248 +1555,324 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
     (*Logs.debug (fun m -> m "_reserve_insert %Ld" depth);*)
     _check_live_integrity fs alloc_id depth;
     match lru_get fs.node_cache.lru alloc_id with
-    |None -> failwith @@ Printf.sprintf "Missing LRU entry for %Ld (insert)" alloc_id
-    |Some entry ->
-      if has_free_space entry space then begin
-        _reserve_dirty fs.node_cache alloc_id 0L depth;
-        Lwt.return ()
-      end
-      else if not split_path && _has_children entry && _has_logdata entry then begin
-        (* log spilling *)
-        let children = Lazy.force entry.children in
-        let find_victim () =
-          let spill_score = ref 0 in
-          let best_spill_score = ref 0 in
-          (* an iterator on entry.children keys would be helpful here *)
-          let scored_key = ref @@ fst @@ unwrap_opt @@ KeyedMap.min_binding children in
-          let best_spill_key = ref !scored_key in
-          KeyedMap.iter (fun k va -> begin
-            if String.compare k !scored_key > 0 then begin
-              if !spill_score > !best_spill_score then begin
-                best_spill_score := !spill_score;
-                best_spill_key := !scored_key;
-              end;
-              spill_score := 0;
-              match KeyedMap.find_first_opt k children with
-              |None -> string_dump k; string_dump @@ fst @@ unwrap_opt @@ KeyedMap.max_binding children; string_dump entry.highest_key; failwith "children invariant broken"
-              |Some (sk, _cl) ->
-                scored_key := sk;
-            end;
-            let len = String.length va in
-            let len1 = P.key_size + sizeof_datalen + len in
-            spill_score := !spill_score + len1;
-          end) entry.logdata.logdata_contents;
-          if !spill_score > !best_spill_score then begin
-            best_spill_score := !spill_score;
-            best_spill_key := !scored_key;
-          end;
-          !best_spill_score, !best_spill_key
-        in
-        let best_spill_score, best_spill_key = find_victim () in
-        Logs.debug (fun m -> m "log spilling %Ld %Ld %d" depth alloc_id best_spill_score);
-        let offset = keyedmap_find best_spill_key children in
-        let%lwt child_alloc_id, _ce = _preload_child fs alloc_id entry best_spill_key offset in begin
-        let clo = entry.childlinks.childlinks_offset in
-        let nko = entry.logdata.value_end in
-        (*Logs.debug (fun m -> m "Before _reserve_insert nko %d" entry.logdata.value_end);*)
-        _reserve_insert fs child_alloc_id (InsSpaceValue best_spill_score) false @@ Int64.succ depth >>= fun () -> begin
-        (*Logs.debug (fun m -> m "After _reserve_insert nko %d" entry.logdata.value_end);*)
-        if clo = entry.childlinks.childlinks_offset && nko = entry.logdata.value_end then begin
-        (* _reserve_insert didn't split the child or the root *)
-          _reserve_dirty fs.node_cache child_alloc_id 0L @@ Int64.succ depth;
-          let before_bsk_succ = match KeyedMap.find_last_opt best_spill_key children with
-            |Some (before_bsk, _va) -> next_key before_bsk
-            |None -> zero_key
+    | None ->
+        failwith
+        @@ Printf.sprintf "Missing LRU entry for %Ld (insert)" alloc_id
+    | Some entry -> (
+        if has_free_space entry space then (
+          _reserve_dirty fs.node_cache alloc_id 0L depth;
+          Lwt.return () )
+        else if (not split_path) && _has_children entry && _has_logdata entry
+        then (
+          (* log spilling *)
+          let children = Lazy.force entry.children in
+          let find_victim () =
+            let spill_score = ref 0 in
+            let best_spill_score = ref 0 in
+            (* an iterator on entry.children keys would be helpful here *)
+            let scored_key =
+              ref @@ fst @@ unwrap_opt @@ KeyedMap.min_binding children
+            in
+            let best_spill_key = ref !scored_key in
+            KeyedMap.iter
+              (fun k va ->
+                if String.compare k !scored_key > 0 then (
+                  if !spill_score > !best_spill_score then (
+                    best_spill_score := !spill_score;
+                    best_spill_key := !scored_key );
+                  spill_score := 0;
+                  match KeyedMap.find_first_opt k children with
+                  | None ->
+                      string_dump k;
+                      string_dump
+                      @@ fst
+                      @@ unwrap_opt
+                      @@ KeyedMap.max_binding children;
+                      string_dump entry.highest_key;
+                      failwith "children invariant broken"
+                  | Some (sk, _cl) ->
+                      scored_key := sk );
+                let len = String.length va in
+                let len1 = P.key_size + sizeof_datalen + len in
+                spill_score := !spill_score + len1 )
+              entry.logdata.logdata_contents;
+            if !spill_score > !best_spill_score then (
+              best_spill_score := !spill_score;
+              best_spill_key := !scored_key );
+            (!best_spill_score, !best_spill_key)
           in
-        (* which keys we will dispatch *)
-        let carved_map = KeyedMap.carve_inclusive_range
-          before_bsk_succ best_spill_key entry.logdata.logdata_contents
-        in
-        entry.logdata.value_end <- entry.logdata.value_end - best_spill_score;
-        KeyedMap.iter (fun key va ->
-          _fast_insert fs child_alloc_id key (InsValue va) @@
-          Int64.succ depth) carved_map;
-        end;
-        _reserve_insert fs alloc_id space split_path depth
-        end
-      end
-      end
-      else match entry.parent_key with
-        |None -> begin (* Node splitting (root) *)
-            assert (depth = 0L);
-            Logs.debug (fun m -> m "node splitting %Ld %Ld" depth alloc_id);
-            let kc = entry.logdata.logdata_contents in
-            let children = Lazy.force entry.children in
-            _reserve_dirty fs.node_cache alloc_id 2L depth;
-            let di = _mark_dirty fs.node_cache alloc_id in
-            let median = _split_point entry in
-            let alloc1, entry1 = _new_node fs 2 (Some alloc_id) median entry.rdepth in
-            let alloc2, entry2 = _new_node fs 2 (Some alloc_id) entry.highest_key entry.rdepth in
-            let kc2 = KeyedMap.split_off_after median kc in
-            let cl2 = KeyedMap.split_off_after median children in
-            let ca2 = KeyedMap.split_off_after median entry.children_alloc_ids in
-            let fc2 = KeyedMap.split_off_after median di.flush_children in
-        let blit_cd_child k offset centry =
-          let cstr0 = entry.raw_node in
-          let cstr1 = centry.raw_node in
-          let offset1 = centry.childlinks.childlinks_offset - childlink_size in
-          centry.childlinks.childlinks_offset <- offset1;
-          Cstruct.blit cstr0 (Int64.to_int offset) cstr1 offset1 childlink_size;
-          assert (Lazy.is_val centry.children);
-          let key1 = Cstruct.to_string @@ Cstruct.sub cstr1 offset1 P.key_size in
-          Logs.debug (fun m -> m "Blitting %S (%S) from offset %Ld" key1 k offset);
-          assert (k = key1);
-          KeyedMap.xadd key1 (Int64.of_int offset1) (Lazy.force centry.children);
-        in
-        KeyedMap.iter (fun _k va -> entry1.logdata.value_end <- entry1.logdata.value_end + String.length va + P.key_size + sizeof_datalen) kc;
-        KeyedMap.iter (fun _k va -> entry2.logdata.value_end <- entry2.logdata.value_end + String.length va + P.key_size + sizeof_datalen) kc2;
-        KeyedMap.iter (fun k off -> blit_cd_child k off entry1) children;
-        KeyedMap.iter (fun k off -> blit_cd_child k off entry2) cl2;
-        KeyedMap.swap entry1.logdata.logdata_contents kc;
-        KeyedMap.swap entry2.logdata.logdata_contents kc2;
-        entry1.children_alloc_ids <- entry.children_alloc_ids;
-        entry2.children_alloc_ids <- ca2;
-        _reset_contents entry;
-        entry.rdepth <- Int32.succ entry.rdepth;
-        set_rootnode_hdr_depth entry.raw_node entry.rdepth;
-        entry.flush_info <- Some { flush_children=KeyedMap.create () };
-        _fixup_parent_links fs.node_cache alloc1 entry1;
-        _fixup_parent_links fs.node_cache alloc2 entry2;
-        _add_child entry entry1 alloc1 fs.node_cache alloc_id;
-        _add_child entry entry2 alloc2 fs.node_cache alloc_id;
-        entry1.flush_info <- Some { flush_children=di.flush_children };
-        entry2.flush_info <- Some { flush_children=fc2 };
-        Lwt.return_unit
-      end
-      |Some parent_key -> begin (* Node splitting (non root) *)
-        assert (Int64.compare depth 0L > 0);
-        Logs.debug (fun m -> m "node splitting %Ld %Ld" depth alloc_id);
-        (* Set split_path to prevent spill/split recursion; will split towards the root *)
-        _reserve_insert fs parent_key (InsSpaceChild childlink_size) true @@ Int64.pred depth >>= fun () ->
-        let _children = Lazy.force entry.children in
-        _reserve_dirty fs.node_cache alloc_id 1L depth;
-        let di = _mark_dirty fs.node_cache alloc_id in
-        let median = _split_point entry in
-        let alloc1, entry1 = _new_node fs 2 (Some parent_key) median entry.rdepth in begin
-
-        let to_remove = ref [] in
-        let remove_size = ref 0 in
-        let kc1 = KeyedMap.split_off_after
-            median entry.logdata.logdata_contents in
-        KeyedMap.swap kc1 entry.logdata.logdata_contents;
-        KeyedMap.iter (fun key va ->
-            let len = String.length va in
-            let len1 = len + P.key_size + sizeof_datalen in
-            _fast_insert fs alloc1 key (InsValue va) depth;
-            remove_size := !remove_size + len1;
-            to_remove := key::!to_remove;
-          ) kc1;
-        List.iter (fun key ->
-            KeyedMap.remove key entry.logdata.logdata_contents
-          ) !to_remove;
-        entry.logdata.value_end <- entry.logdata.value_end - !remove_size;
-
-        let clo_out = ref block_end in
-        let clo_out1 = ref block_end in
-        let clo = ref @@ block_end - childlink_size in
-        let children = Lazy.force entry.children in
-        let children1 = KeyedMap.create () in
-        let fc1 = KeyedMap.create () in
-        while !clo >= entry.childlinks.childlinks_offset do
-        (* Move children data *)
-          let key1 = Cstruct.to_string @@ Cstruct.sub entry.raw_node !clo P.key_size in
-          if String.compare key1 median <= 0 then begin
-            clo_out1 := !clo_out1 - childlink_size;
-            Cstruct.blit entry.raw_node !clo entry1.raw_node !clo_out1 childlink_size;
-            begin match KeyedMap.find_opt key1 entry.children_alloc_ids with
-            |Some alloc_id ->
-              KeyedMap.remove key1 entry.children_alloc_ids;
-              KeyedMap.xadd key1 alloc_id entry1.children_alloc_ids;
-            |None ->
-              ()
-            end;
-            KeyedMap.remove key1 children;
-            KeyedMap.xadd key1 (Int64.of_int !clo_out1) children1;
-            if KeyedMap.mem key1 di.flush_children then begin
-              let child_alloc_id = keyedmap_find key1 di.flush_children in
-              KeyedMap.remove key1 di.flush_children;
-              KeyedMap.xadd key1 child_alloc_id fc1;
-            end
-          end else begin
-            clo_out := !clo_out - childlink_size;
-            Cstruct.blit entry.raw_node !clo entry.raw_node !clo_out childlink_size;
-            let key1 = Cstruct.to_string @@ Cstruct.sub entry.raw_node !clo_out P.key_size in
-            KeyedMap.update key1 (Int64.of_int !clo_out) children
-          end
-        done;
-        entry.childlinks.childlinks_offset <- !clo_out;
-        entry1.childlinks.childlinks_offset <- !clo_out1;
-        entry1.children <- Lazy.from_val children1;
-        _fixup_parent_links fs.node_cache alloc1 entry1;
-        (* Hook new node into parent *)
-        match lru_peek fs.node_cache.lru parent_key with
-        |None -> failwith @@ Printf.sprintf "Missing LRU entry for %Ld (parent)" alloc_id
-        |Some parent -> begin
-          _add_child parent entry1 alloc1 fs.node_cache parent_key;
-          entry1.flush_info <- Some { flush_children = fc1 };
-          match parent.flush_info with
-          |None -> failwith "Missing flush_info for parent"
-          |Some di ->
-              KeyedMap.add median alloc1 di.flush_children;
-          end;
-        _reserve_insert fs alloc_id space split_path depth;
-      end
-      end
+          let best_spill_score, best_spill_key = find_victim () in
+          Logs.debug (fun m ->
+              m "log spilling %Ld %Ld %d" depth alloc_id best_spill_score );
+          let offset = keyedmap_find best_spill_key children in
+          let%lwt child_alloc_id, _ce =
+            _preload_child fs alloc_id entry best_spill_key offset
+          in
+          let clo = entry.childlinks.childlinks_offset in
+          let nko = entry.logdata.value_end in
+          (*Logs.debug (fun m -> m "Before _reserve_insert nko %d" entry.logdata.value_end);*)
+          _reserve_insert fs child_alloc_id (InsSpaceValue best_spill_score)
+            false
+          @@ Int64.succ depth
+          >>= fun () ->
+          (*Logs.debug (fun m -> m "After _reserve_insert nko %d" entry.logdata.value_end);*)
+          if
+            clo = entry.childlinks.childlinks_offset
+            && nko = entry.logdata.value_end
+          then (
+            (* _reserve_insert didn't split the child or the root *)
+            _reserve_dirty fs.node_cache child_alloc_id 0L @@ Int64.succ depth;
+            let before_bsk_succ =
+              match KeyedMap.find_last_opt best_spill_key children with
+              | Some (before_bsk, _va) ->
+                  next_key before_bsk
+              | None ->
+                  zero_key
+            in
+            (* which keys we will dispatch *)
+            let carved_map =
+              KeyedMap.carve_inclusive_range before_bsk_succ best_spill_key
+                entry.logdata.logdata_contents
+            in
+            (entry.logdata).value_end
+            <- entry.logdata.value_end - best_spill_score;
+            KeyedMap.iter
+              (fun key va ->
+                _fast_insert fs child_alloc_id key (InsValue va)
+                @@ Int64.succ depth )
+              carved_map );
+          _reserve_insert fs alloc_id space split_path depth )
+        else
+          match entry.parent_key with
+          | None ->
+              (* Node splitting (root) *)
+              assert (depth = 0L);
+              Logs.debug (fun m -> m "node splitting %Ld %Ld" depth alloc_id);
+              let kc = entry.logdata.logdata_contents in
+              let children = Lazy.force entry.children in
+              _reserve_dirty fs.node_cache alloc_id 2L depth;
+              let di = _mark_dirty fs.node_cache alloc_id in
+              let median = _split_point entry in
+              let alloc1, entry1 =
+                _new_node fs 2 (Some alloc_id) median entry.rdepth
+              in
+              let alloc2, entry2 =
+                _new_node fs 2 (Some alloc_id) entry.highest_key entry.rdepth
+              in
+              let kc2 = KeyedMap.split_off_after median kc in
+              let cl2 = KeyedMap.split_off_after median children in
+              let ca2 =
+                KeyedMap.split_off_after median entry.children_alloc_ids
+              in
+              let fc2 = KeyedMap.split_off_after median di.flush_children in
+              let blit_cd_child k offset centry =
+                let cstr0 = entry.raw_node in
+                let cstr1 = centry.raw_node in
+                let offset1 =
+                  centry.childlinks.childlinks_offset - childlink_size
+                in
+                (centry.childlinks).childlinks_offset <- offset1;
+                Cstruct.blit cstr0 (Int64.to_int offset) cstr1 offset1
+                  childlink_size;
+                assert (Lazy.is_val centry.children);
+                let key1 =
+                  Cstruct.to_string @@ Cstruct.sub cstr1 offset1 P.key_size
+                in
+                Logs.debug (fun m ->
+                    m "Blitting %S (%S) from offset %Ld" key1 k offset );
+                assert (k = key1);
+                KeyedMap.xadd key1 (Int64.of_int offset1)
+                  (Lazy.force centry.children)
+              in
+              KeyedMap.iter
+                (fun _k va ->
+                  (entry1.logdata).value_end
+                  <- entry1.logdata.value_end
+                     + String.length va
+                     + P.key_size
+                     + sizeof_datalen )
+                kc;
+              KeyedMap.iter
+                (fun _k va ->
+                  (entry2.logdata).value_end
+                  <- entry2.logdata.value_end
+                     + String.length va
+                     + P.key_size
+                     + sizeof_datalen )
+                kc2;
+              KeyedMap.iter (fun k off -> blit_cd_child k off entry1) children;
+              KeyedMap.iter (fun k off -> blit_cd_child k off entry2) cl2;
+              KeyedMap.swap entry1.logdata.logdata_contents kc;
+              KeyedMap.swap entry2.logdata.logdata_contents kc2;
+              entry1.children_alloc_ids <- entry.children_alloc_ids;
+              entry2.children_alloc_ids <- ca2;
+              _reset_contents entry;
+              entry.rdepth <- Int32.succ entry.rdepth;
+              set_rootnode_hdr_depth entry.raw_node entry.rdepth;
+              entry.flush_info <- Some {flush_children = KeyedMap.create ()};
+              _fixup_parent_links fs.node_cache alloc1 entry1;
+              _fixup_parent_links fs.node_cache alloc2 entry2;
+              _add_child entry entry1 alloc1 fs.node_cache alloc_id;
+              _add_child entry entry2 alloc2 fs.node_cache alloc_id;
+              entry1.flush_info <- Some {flush_children = di.flush_children};
+              entry2.flush_info <- Some {flush_children = fc2};
+              Lwt.return_unit
+          | Some parent_key -> (
+              (* Node splitting (non root) *)
+              assert (Int64.compare depth 0L > 0);
+              Logs.debug (fun m -> m "node splitting %Ld %Ld" depth alloc_id);
+              (* Set split_path to prevent spill/split recursion; will split towards the root *)
+              _reserve_insert fs parent_key (InsSpaceChild childlink_size)
+                true
+              @@ Int64.pred depth
+              >>= fun () ->
+              let _children = Lazy.force entry.children in
+              _reserve_dirty fs.node_cache alloc_id 1L depth;
+              let di = _mark_dirty fs.node_cache alloc_id in
+              let median = _split_point entry in
+              let alloc1, entry1 =
+                _new_node fs 2 (Some parent_key) median entry.rdepth
+              in
+              let to_remove = ref [] in
+              let remove_size = ref 0 in
+              let kc1 =
+                KeyedMap.split_off_after median entry.logdata.logdata_contents
+              in
+              KeyedMap.swap kc1 entry.logdata.logdata_contents;
+              KeyedMap.iter
+                (fun key va ->
+                  let len = String.length va in
+                  let len1 = len + P.key_size + sizeof_datalen in
+                  _fast_insert fs alloc1 key (InsValue va) depth;
+                  remove_size := !remove_size + len1;
+                  to_remove := key :: !to_remove )
+                kc1;
+              List.iter
+                (fun key -> KeyedMap.remove key entry.logdata.logdata_contents)
+                !to_remove;
+              (entry.logdata).value_end
+              <- entry.logdata.value_end - !remove_size;
+              let clo_out = ref block_end in
+              let clo_out1 = ref block_end in
+              let clo = ref @@ (block_end - childlink_size) in
+              let children = Lazy.force entry.children in
+              let children1 = KeyedMap.create () in
+              let fc1 = KeyedMap.create () in
+              while !clo >= entry.childlinks.childlinks_offset do
+                (* Move children data *)
+                let key1 =
+                  Cstruct.to_string
+                  @@ Cstruct.sub entry.raw_node !clo P.key_size
+                in
+                if String.compare key1 median <= 0 then (
+                  clo_out1 := !clo_out1 - childlink_size;
+                  Cstruct.blit entry.raw_node !clo entry1.raw_node !clo_out1
+                    childlink_size;
+                  ( match KeyedMap.find_opt key1 entry.children_alloc_ids with
+                  | Some alloc_id ->
+                      KeyedMap.remove key1 entry.children_alloc_ids;
+                      KeyedMap.xadd key1 alloc_id entry1.children_alloc_ids
+                  | None ->
+                      () );
+                  KeyedMap.remove key1 children;
+                  KeyedMap.xadd key1 (Int64.of_int !clo_out1) children1;
+                  if KeyedMap.mem key1 di.flush_children then (
+                    let child_alloc_id =
+                      keyedmap_find key1 di.flush_children
+                    in
+                    KeyedMap.remove key1 di.flush_children;
+                    KeyedMap.xadd key1 child_alloc_id fc1 ) )
+                else (
+                  clo_out := !clo_out - childlink_size;
+                  Cstruct.blit entry.raw_node !clo entry.raw_node !clo_out
+                    childlink_size;
+                  let key1 =
+                    Cstruct.to_string
+                    @@ Cstruct.sub entry.raw_node !clo_out P.key_size
+                  in
+                  KeyedMap.update key1 (Int64.of_int !clo_out) children )
+              done;
+              (entry.childlinks).childlinks_offset <- !clo_out;
+              (entry1.childlinks).childlinks_offset <- !clo_out1;
+              entry1.children <- Lazy.from_val children1;
+              _fixup_parent_links fs.node_cache alloc1 entry1;
+              (* Hook new node into parent *)
+              match lru_peek fs.node_cache.lru parent_key with
+              | None ->
+                  failwith
+                  @@ Printf.sprintf "Missing LRU entry for %Ld (parent)"
+                       alloc_id
+              | Some parent ->
+                  ( _add_child parent entry1 alloc1 fs.node_cache parent_key;
+                    entry1.flush_info <- Some {flush_children = fc1};
+                    match parent.flush_info with
+                    | None ->
+                        failwith "Missing flush_info for parent"
+                    | Some di ->
+                        KeyedMap.add median alloc1 di.flush_children );
+                  _reserve_insert fs alloc_id space split_path depth ) )
 
   let insert root key value =
     (*Logs.debug (fun m -> m "insert");*)
     let stats = root.open_fs.node_cache.statistics in
     stats.inserts <- succ stats.inserts;
     _check_live_integrity root.open_fs root.root_key 0L;
-    _reserve_insert root.open_fs root.root_key (_ins_req_space @@ InsValue value) false 0L >>= fun () ->
-    begin
-      _check_live_integrity root.open_fs root.root_key 0L;
-      _fast_insert root.open_fs root.root_key key (InsValue value) 0L;
-      _check_live_integrity root.open_fs root.root_key 0L;
-      Lwt.return ()
-    end
+    _reserve_insert root.open_fs root.root_key
+      (_ins_req_space @@ InsValue value)
+      false 0L
+    >>= fun () ->
+    _check_live_integrity root.open_fs root.root_key 0L;
+    _fast_insert root.open_fs root.root_key key (InsValue value) 0L;
+    _check_live_integrity root.open_fs root.root_key 0L;
+    Lwt.return ()
 
   let rec _lookup open_fs alloc_id key =
     Logs.debug (fun m -> m "_lookup");
     match lru_get open_fs.node_cache.lru alloc_id with
-    |None ->
-      Logs.err (fun m -> m "Missing LRU entry for %Ld (lookup)" alloc_id);
-      failwith @@ Printf.sprintf "Missing LRU entry for %Ld (lookup)" alloc_id
-    |Some entry ->
-      match
-        KeyedMap.find_opt key entry.logdata.logdata_contents
-      with
-        |Some va ->
+    | None ->
+        Logs.err (fun m -> m "Missing LRU entry for %Ld (lookup)" alloc_id);
+        failwith
+        @@ Printf.sprintf "Missing LRU entry for %Ld (lookup)" alloc_id
+    | Some entry -> (
+      match KeyedMap.find_opt key entry.logdata.logdata_contents with
+      | Some va ->
           (*Logs.debug (fun m -> m "Found");*)
-          if _is_value open_fs.filesystem va
-          then Lwt.return_some va
+          if _is_value open_fs.filesystem va then Lwt.return_some va
           else Lwt.return_none
-        |None ->
-          if not @@ _has_children entry then Lwt.return_none else
-            let key1, offset = unwrap_opt @@ KeyedMap.find_first_opt key @@ Lazy.force entry.children in
-            let%lwt child_alloc_id, _ce = _preload_child open_fs alloc_id entry key1 offset in
-            _lookup open_fs child_alloc_id key
+      | None ->
+          if not @@ _has_children entry then Lwt.return_none
+          else
+            let key1, offset =
+              unwrap_opt
+              @@ KeyedMap.find_first_opt key
+              @@ Lazy.force entry.children
+            in
+            let%lwt child_alloc_id, _ce =
+              _preload_child open_fs alloc_id entry key1 offset
+            in
+            _lookup open_fs child_alloc_id key )
 
   let rec _mem open_fs alloc_id key =
     match lru_get open_fs.node_cache.lru alloc_id with
-    |None -> failwith @@ Printf.sprintf "Missing LRU entry for %Ld (mem)" alloc_id
-    |Some entry ->
-      match
-        KeyedMap.find_opt key entry.logdata.logdata_contents
-      with
-        |Some va ->
-            Lwt.return @@ _is_value open_fs.filesystem va
-        |None ->
-            Logs.debug (fun m -> m "_mem");
-            if not @@ _has_children entry then Lwt.return_false else
-            let key1, offset = unwrap_opt @@ KeyedMap.find_first_opt key @@ Lazy.force entry.children in
-            let%lwt child_alloc_id, _ce = _preload_child open_fs alloc_id entry key1 offset in
-            _mem open_fs child_alloc_id key
+    | None ->
+        failwith @@ Printf.sprintf "Missing LRU entry for %Ld (mem)" alloc_id
+    | Some entry -> (
+      match KeyedMap.find_opt key entry.logdata.logdata_contents with
+      | Some va ->
+          Lwt.return @@ _is_value open_fs.filesystem va
+      | None ->
+          Logs.debug (fun m -> m "_mem");
+          if not @@ _has_children entry then Lwt.return_false
+          else
+            let key1, offset =
+              unwrap_opt
+              @@ KeyedMap.find_first_opt key
+              @@ Lazy.force entry.children
+            in
+            let%lwt child_alloc_id, _ce =
+              _preload_child open_fs alloc_id entry key1 offset
+            in
+            _mem open_fs child_alloc_id key )
 
   let lookup root key =
     let stats = root.open_fs.node_cache.statistics in
@@ -1498,21 +1886,33 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
 
   let rec _search_range open_fs alloc_id start end_ seen callback =
     match lru_get open_fs.node_cache.lru alloc_id with
-    |None -> failwith @@ Printf.sprintf "Missing LRU entry for %Ld (search_range)" alloc_id
-    |Some entry ->
-      let seen1 = ref seen in
-      let lwt_queue = ref [] in
-      (* The range from start inclusive to end_ exclusive *)
-      KeyedMap.iter_range start end_ (fun k va -> (match _value_at open_fs.filesystem va with Some v -> callback k v|None ->() ); seen1 := KeyedSet.add k !seen1)
-      entry.logdata.logdata_contents;
-      (* As above, but end at end_ inclusive *)
-      KeyedMap.iter_inclusive_range start end_ (fun key1 offset ->
-        lwt_queue := (key1, offset)::!lwt_queue)
-      @@ Lazy.force entry.children;
-      Lwt_list.iter_s (fun (key1, offset) ->
-          let%lwt child_alloc_id, _ce =
-            _preload_child open_fs alloc_id entry key1 offset in
-          _search_range open_fs child_alloc_id start end_ !seen1 callback) !lwt_queue
+    | None ->
+        failwith
+        @@ Printf.sprintf "Missing LRU entry for %Ld (search_range)" alloc_id
+    | Some entry ->
+        let seen1 = ref seen in
+        let lwt_queue = ref [] in
+        (* The range from start inclusive to end_ exclusive *)
+        KeyedMap.iter_range start end_
+          (fun k va ->
+            ( match _value_at open_fs.filesystem va with
+            | Some v ->
+                callback k v
+            | None ->
+                () );
+            seen1 := KeyedSet.add k !seen1 )
+          entry.logdata.logdata_contents;
+        (* As above, but end at end_ inclusive *)
+        KeyedMap.iter_inclusive_range start end_ (fun key1 offset ->
+            lwt_queue := (key1, offset) :: !lwt_queue )
+        @@ Lazy.force entry.children;
+        Lwt_list.iter_s
+          (fun (key1, offset) ->
+            let%lwt child_alloc_id, _ce =
+              _preload_child open_fs alloc_id entry key1 offset
+            in
+            _search_range open_fs child_alloc_id start end_ !seen1 callback )
+          !lwt_queue
 
   (* The range from start inclusive to end_ exclusive
      Results are in no particular order. *)
@@ -1524,18 +1924,28 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
 
   let rec _iter open_fs alloc_id callback =
     match lru_get open_fs.node_cache.lru alloc_id with
-    |None -> failwith @@ Printf.sprintf "Missing LRU entry for %Ld (iter)" alloc_id
-    |Some entry ->
-      let lwt_queue = ref [] in
-      KeyedMap.iter (fun k va -> (match _value_at open_fs.filesystem va with Some v -> callback k v|None ->() ))
-      entry.logdata.logdata_contents;
-      KeyedMap.iter (fun key1 offset ->
-        lwt_queue := (key1, offset)::!lwt_queue)
-      @@ Lazy.force entry.children;
-      Lwt_list.iter_s (fun (key1, offset) ->
-          let%lwt child_alloc_id, _ce =
-            _preload_child open_fs alloc_id entry key1 offset in
-          _iter open_fs child_alloc_id callback) !lwt_queue
+    | None ->
+        failwith @@ Printf.sprintf "Missing LRU entry for %Ld (iter)" alloc_id
+    | Some entry ->
+        let lwt_queue = ref [] in
+        KeyedMap.iter
+          (fun k va ->
+            match _value_at open_fs.filesystem va with
+            | Some v ->
+                callback k v
+            | None ->
+                () )
+          entry.logdata.logdata_contents;
+        KeyedMap.iter (fun key1 offset ->
+            lwt_queue := (key1, offset) :: !lwt_queue )
+        @@ Lazy.force entry.children;
+        Lwt_list.iter_s
+          (fun (key1, offset) ->
+            let%lwt child_alloc_id, _ce =
+              _preload_child open_fs alloc_id entry key1 offset
+            in
+            _iter open_fs child_alloc_id callback )
+          !lwt_queue
 
   let iter root callback =
     let stats = root.open_fs.node_cache.statistics in
@@ -1545,36 +1955,46 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
   let _read_superblock fs =
     let block_io = _get_superblock_io () in
     let block_io_fanned = make_fanned_io_list fs.sector_size block_io in
-    B.read fs.disk 0L block_io_fanned >>= Lwt.wrap1 begin function
-      |Result.Error _ -> raise ReadError
-      |Result.Ok () ->
-          let sb = _sb_io block_io in
-      if copy_superblock_magic sb <> superblock_magic
-      then raise BadMagic
-      else if get_superblock_version sb <> superblock_version
-      then raise BadVersion
-      else if get_superblock_incompat_flags sb <> sb_required_incompat
-      then raise BadFlags
-      else if not @@ Wodan_crc32c.cstruct_valid sb
-      then raise @@ BadCRC 0L
-      else if get_superblock_block_size sb <> Int32.of_int P.block_size
-      then begin
-        Logs.err (fun m -> m "Bad superblock size %ld %d" (get_superblock_block_size sb) P.block_size);
-        raise BadParams
-      end
-      else if get_superblock_key_size sb <> P.key_size
-      then raise BadParams
-      else get_superblock_first_block_written sb, get_superblock_logical_size sb, Cstruct.to_string @@ get_superblock_fsid sb
-    end
+    B.read fs.disk 0L block_io_fanned
+    >>= Lwt.wrap1 (function
+          | Result.Error _ ->
+              raise ReadError
+          | Result.Ok () ->
+              let sb = _sb_io block_io in
+              if copy_superblock_magic sb <> superblock_magic then
+                raise BadMagic
+              else if get_superblock_version sb <> superblock_version then
+                raise BadVersion
+              else if get_superblock_incompat_flags sb <> sb_required_incompat
+              then raise BadFlags
+              else if not @@ Wodan_crc32c.cstruct_valid sb then
+                raise @@ BadCRC 0L
+              else if
+                get_superblock_block_size sb <> Int32.of_int P.block_size
+              then (
+                Logs.err (fun m ->
+                    m "Bad superblock size %ld %d"
+                      (get_superblock_block_size sb)
+                      P.block_size );
+                raise BadParams )
+              else if get_superblock_key_size sb <> P.key_size then
+                raise BadParams
+              else
+                ( get_superblock_first_block_written sb,
+                  get_superblock_logical_size sb,
+                  Cstruct.to_string @@ get_superblock_fsid sb ) )
 
   (* Requires the caller to discard the entire device first.
      Don't add call sites beyond prepare_io, the io pages must be zeroed *)
   let _format open_fs logical_size first_block_written fsid =
     let block_io = _get_superblock_io () in
-    let block_io_fanned = make_fanned_io_list open_fs.filesystem.sector_size block_io in
+    let block_io_fanned =
+      make_fanned_io_list open_fs.filesystem.sector_size block_io
+    in
     let alloc_id, _root = _new_root open_fs in
-    open_fs.node_cache.new_count <- 1L;
-    _write_node open_fs alloc_id >>= fun () -> begin
+    (open_fs.node_cache).new_count <- 1L;
+    _write_node open_fs alloc_id
+    >>= fun () ->
     _log_statistics open_fs.node_cache;
     let sb = _sb_io block_io in
     set_superblock_magic superblock_magic 0 sb;
@@ -1586,158 +2006,177 @@ module Make(B: EXTBLOCK)(P: SUPERBLOCK_PARAMS) : (S with type disk = B.t) = stru
     set_superblock_logical_size sb logical_size;
     set_superblock_fsid fsid 0 sb;
     Wodan_crc32c.cstruct_reset sb;
-    B.write open_fs.filesystem.disk 0L block_io_fanned >>= function
-      |Result.Ok () -> Lwt.return ()
-      |Result.Error _ -> Lwt.fail WriteError
-    end
+    B.write open_fs.filesystem.disk 0L block_io_fanned
+    >>= function
+    | Result.Ok () ->
+        Lwt.return ()
+    | Result.Error _ ->
+        Lwt.fail WriteError
 
-  let _mid_range start end_ lsize = (* might overflow, limit lsize *)
+  let _mid_range start end_ lsize =
+    (* might overflow, limit lsize *)
     (* if start = end_, we pick the farthest logical address *)
-    if Int64.(succ start) = end_ || (
-      Int64.(succ start) = lsize && end_ = 1L) then None else
-    let end_ = if Int64.compare start end_ < 0 then end_ else Int64.(add end_ lsize) in
-    let mid = Int64.(shift_right_logical (add start end_) 1) in
-    let mid = Int64.(rem mid lsize) in
-    let mid = if mid = 0L then 1L else mid in
-    Some mid
+    if Int64.(succ start) = end_ || (Int64.(succ start) = lsize && end_ = 1L)
+    then None
+    else
+      let end_ =
+        if Int64.compare start end_ < 0 then end_ else Int64.(add end_ lsize)
+      in
+      let mid = Int64.(shift_right_logical (add start end_) 1) in
+      let mid = Int64.(rem mid lsize) in
+      let mid = if mid = 0L then 1L else mid in
+      Some mid
 
   let _scan_for_root fs start0 lsize fsid =
     Logs.debug (fun m -> m "_scan_for_root");
     let cstr = _get_block_io () in
     let io_data = make_fanned_io_list fs.sector_size cstr in
-
     let read logical =
-      B.read fs.disk Int64.(div (mul logical @@ of_int P.block_size) @@ of_int fs.other_sector_size) io_data >>= function
-      |Result.Error _ -> Lwt.fail ReadError
-      |Result.Ok () -> Lwt.return () in
-
+      B.read fs.disk
+        Int64.(
+          div (mul logical @@ of_int P.block_size)
+          @@ of_int fs.other_sector_size)
+        io_data
+      >>= function
+      | Result.Error _ ->
+          Lwt.fail ReadError
+      | Result.Ok () ->
+          Lwt.return ()
+    in
     let next_logical logical =
       let log1 = Int64.succ logical in
       if log1 = lsize then 1L else log1
     in
-
     let is_valid_root () =
       get_anynode_hdr_nodetype cstr = 1
       && Cstruct.to_string @@ get_anynode_hdr_fsid cstr = fsid
       && Wodan_crc32c.cstruct_valid cstr
     in
-
     let rec _scan_range start end_opt =
       if Some start = end_opt then
         Lwt.fail @@ Failure "Didn't find a valid root"
-      else begin
-        let end_opt = if end_opt = None then Some start else end_opt in
-      read start >>= fun () ->
-      if is_valid_root () then
-        Lwt.return (start, get_anynode_hdr_generation cstr)
       else
-        _scan_range (next_logical start) end_opt
-    end
+        let end_opt = if end_opt = None then Some start else end_opt in
+        read start
+        >>= fun () ->
+        if is_valid_root () then
+          Lwt.return (start, get_anynode_hdr_generation cstr)
+        else _scan_range (next_logical start) end_opt
     in
-
     let rec sfr_rec start0 end0 gen0 =
       (* end/start swapped on purpose *)
       match _mid_range end0 start0 lsize with
-      | None -> Lwt.return end0
+      | None ->
+          Lwt.return end0
       | Some start1 ->
-      let%lwt end1, gen1 = _scan_range start1 None in
-      if gen0 < gen1
-      then sfr_rec start0 end1 gen1
-      else sfr_rec start1 end0 gen0 in
-
-    let%lwt end0, gen0 = _scan_range start0 None
-    in sfr_rec start0 end0 gen0
+          let%lwt end1, gen1 = _scan_range start1 None in
+          if gen0 < gen1 then sfr_rec start0 end1 gen1
+          else sfr_rec start1 end0 gen0
+    in
+    let%lwt end0, gen0 = _scan_range start0 None in
+    sfr_rec start0 end0 gen0
 
   let prepare_io mode disk mount_options =
-    B.get_info disk >>= fun info ->
-      Logs.debug (fun m -> m "prepare_io sector_size %d" info.sector_size);
-      let sector_size = if false then info.sector_size else 512 in
-      let block_size = P.block_size in
-      let io_size = if block_size >= Io_page.page_size then Io_page.page_size else block_size in
-      assert (block_size >= io_size);
-      assert (io_size >= sector_size);
-      assert (block_size mod io_size = 0);
-      assert (io_size mod sector_size = 0);
-      let fs = {
-        disk;
-        sector_size;
-        other_sector_size = info.sector_size;
-        mount_options;
-      } in
-      match mode with
-        |OpenExistingDevice ->
-            let%lwt fbw, logical_size, fsid = _read_superblock fs in
-            let%lwt lroot = _scan_for_root fs fbw logical_size fsid in
-            let%lwt cstr, _io_data = _load_data_at fs lroot in
-            let typ = get_anynode_hdr_nodetype cstr in
-            if typ <> 1 then raise @@ BadNodeType typ;
-            let root_generation = get_rootnode_hdr_generation cstr in
-            let rdepth = get_rootnode_hdr_depth cstr in
-            let space_map = bitv_create64 logical_size false in
-            Bitv.set space_map 0 true;
-            let scan_map = if mount_options.fast_scan then Some (bitv_create64 logical_size false) else None in
-            let freed_intervals = BlockIntervals.empty in
-            let free_count = Int64.pred logical_size in
-            let node_cache = {
-              lru=lru_create mount_options.cache_size;
-              flush_root=None;
-              next_alloc_id=1L;
-              next_generation=Int64.succ root_generation;
-              logical_size;
-              space_map;
-              scan_map;
-              freed_intervals;
-              free_count;
-              new_count=0L;
-              dirty_count=0L;
-              fsid;
-              next_logical_alloc=lroot; (* in use, but that's okay *)
-              statistics=default_statistics;
-            } in
-            let open_fs = { filesystem=fs; node_cache; } in
-            (* TODO add more integrity checking *)
-            _scan_all_nodes open_fs lroot true rdepth Int64.max_int false >>= fun () ->
-            let%lwt root_key, _entry = _load_root_node_at open_fs lroot in
-            let root = {open_fs; root_key;} in
-            log_statistics root;
-            Lwt.return (root, root_generation)
-        |FormatEmptyDevice logical_size ->
-            assert (logical_size >= 2L);
-            let space_map = bitv_create64 logical_size false in
-            Bitv.set space_map 0 true;
-            let freed_intervals = BlockIntervals.empty in
-            let free_count = Int64.pred logical_size in
-            let first_block_written = Nocrypto.Rng.Int64.gen_r 1L logical_size in
-            let fsid = Cstruct.to_string @@ Nocrypto.Rng.generate 16 in
-            let node_cache = {
-              lru=lru_create mount_options.cache_size;
-              flush_root=None;
-              next_alloc_id=1L;
-              next_generation=1L;
-              logical_size;
-              space_map;
-              scan_map=None;
-              freed_intervals;
-              free_count;
-              new_count=0L;
-              dirty_count=0L;
-              fsid;
-              next_logical_alloc=first_block_written;
-              statistics=default_statistics;
-            } in
-            let open_fs = { filesystem=fs; node_cache; } in
-            _format open_fs logical_size first_block_written fsid >>= fun () ->
-            let root_key = 1L in
-            Lwt.return ({open_fs; root_key;}, 1L)
+    B.get_info disk
+    >>= fun info ->
+    Logs.debug (fun m -> m "prepare_io sector_size %d" info.sector_size);
+    let sector_size = if false then info.sector_size else 512 in
+    let block_size = P.block_size in
+    let io_size =
+      if block_size >= Io_page.page_size then Io_page.page_size
+      else block_size
+    in
+    assert (block_size >= io_size);
+    assert (io_size >= sector_size);
+    assert (block_size mod io_size = 0);
+    assert (io_size mod sector_size = 0);
+    let fs =
+      {disk; sector_size; other_sector_size = info.sector_size; mount_options}
+    in
+    match mode with
+    | OpenExistingDevice ->
+        let%lwt fbw, logical_size, fsid = _read_superblock fs in
+        let%lwt lroot = _scan_for_root fs fbw logical_size fsid in
+        let%lwt cstr, _io_data = _load_data_at fs lroot in
+        let typ = get_anynode_hdr_nodetype cstr in
+        if typ <> 1 then raise @@ BadNodeType typ;
+        let root_generation = get_rootnode_hdr_generation cstr in
+        let rdepth = get_rootnode_hdr_depth cstr in
+        let space_map = bitv_create64 logical_size false in
+        Bitv.set space_map 0 true;
+        let scan_map =
+          if mount_options.fast_scan then
+            Some (bitv_create64 logical_size false)
+          else None
+        in
+        let freed_intervals = BlockIntervals.empty in
+        let free_count = Int64.pred logical_size in
+        let node_cache =
+          { lru = lru_create mount_options.cache_size;
+            flush_root = None;
+            next_alloc_id = 1L;
+            next_generation = Int64.succ root_generation;
+            logical_size;
+            space_map;
+            scan_map;
+            freed_intervals;
+            free_count;
+            new_count = 0L;
+            dirty_count = 0L;
+            fsid;
+            next_logical_alloc = lroot;
+            (* in use, but that's okay *)
+            statistics = default_statistics }
+        in
+        let open_fs = {filesystem = fs; node_cache} in
+        (* TODO add more integrity checking *)
+        _scan_all_nodes open_fs lroot true rdepth Int64.max_int false
+        >>= fun () ->
+        let%lwt root_key, _entry = _load_root_node_at open_fs lroot in
+        let root = {open_fs; root_key} in
+        log_statistics root;
+        Lwt.return (root, root_generation)
+    | FormatEmptyDevice logical_size ->
+        assert (logical_size >= 2L);
+        let space_map = bitv_create64 logical_size false in
+        Bitv.set space_map 0 true;
+        let freed_intervals = BlockIntervals.empty in
+        let free_count = Int64.pred logical_size in
+        let first_block_written = Nocrypto.Rng.Int64.gen_r 1L logical_size in
+        let fsid = Cstruct.to_string @@ Nocrypto.Rng.generate 16 in
+        let node_cache =
+          { lru = lru_create mount_options.cache_size;
+            flush_root = None;
+            next_alloc_id = 1L;
+            next_generation = 1L;
+            logical_size;
+            space_map;
+            scan_map = None;
+            freed_intervals;
+            free_count;
+            new_count = 0L;
+            dirty_count = 0L;
+            fsid;
+            next_logical_alloc = first_block_written;
+            statistics = default_statistics }
+        in
+        let open_fs = {filesystem = fs; node_cache} in
+        _format open_fs logical_size first_block_written fsid
+        >>= fun () ->
+        let root_key = 1L in
+        Lwt.return ({open_fs; root_key}, 1L)
 end
 
-type open_ret = OPEN_RET : (module S with type root = 'a) * 'a * int64 -> open_ret
+type open_ret =
+  | OPEN_RET : (module S with type root = 'a) * 'a * int64 -> open_ret
 
-let open_for_reading
-    (type disk) (module B: EXTBLOCK with type t = disk)
-    disk mount_options =
-  read_superblock_params (module B) disk >>= function sp ->
-    let module Stor = Make(B)(val sp) in
-    Stor.prepare_io OpenExistingDevice disk mount_options >>= function (root, gen) ->
-      Lwt.return (OPEN_RET ((module Stor), root, gen))
-
+let open_for_reading (type disk) (module B : EXTBLOCK with type t = disk) disk
+    mount_options =
+  read_superblock_params (module B) disk
+  >>= function
+  | sp -> (
+      let module Stor = Make (B) ((val sp)) in
+      Stor.prepare_io OpenExistingDevice disk mount_options
+      >>= function
+      | root, gen ->
+          Lwt.return (OPEN_RET ((module Stor), root, gen)) )

--- a/src/wodan/wodan.mli
+++ b/src/wodan/wodan.mli
@@ -1,28 +1,42 @@
 val max_dirty : int
+
 exception BadMagic
+
 exception BadVersion
+
 exception BadFlags
+
 exception BadCRC of int64
+
 exception BadParams
+
 exception ReadError
+
 exception WriteError
+
 exception OutOfSpace
+
 exception NeedsFlush
+
 exception BadKey of string
+
 exception ValueTooLarge of string
+
 exception BadNodeType of int
 
 module type EXTBLOCK = sig
   include Mirage_types_lwt.BLOCK
-  val discard: t -> int64 -> int64 -> (unit, write_error) result io
+
+  val discard : t -> int64 -> int64 -> (unit, write_error) result io
 end
 
-module BlockCompat : functor (B: Mirage_types_lwt.BLOCK) ->
-  EXTBLOCK with type t = B.t
+module BlockCompat (B : Mirage_types_lwt.BLOCK) : EXTBLOCK with type t = B.t
 
 type insertable =
-  |InsValue of string
-  |InsChild of int64 * int64 option (* loc, alloc_id *)
+  | InsValue of string
+  | InsChild of int64 * int64 option
+
+(* loc, alloc_id *)
 
 val sizeof_superblock : int
 
@@ -31,75 +45,108 @@ type mount_options = {
   (* Whether the empty value should be considered a tombstone,
    * meaning that `mem` will return no value when finding it *)
   (* XXX Should this be a superblock flag? *)
-  has_tombstone: bool;
+  has_tombstone : bool;
   (* If enabled, instead of checking the entire filesystem when opening,
    * leaf nodes won't be scanned.  They will be scanned on open instead. *)
-  fast_scan: bool;
+  fast_scan : bool;
   (* How many blocks to keep in cache *)
-  cache_size: int;
+  cache_size : int
 }
 
 (* All parameters that can be read from the superblock *)
 module type SUPERBLOCK_PARAMS = sig
   (* Size of blocks, in bytes *)
-  val block_size: int
+  val block_size : int
+
   (* The exact size of all keys, in bytes *)
-  val key_size: int
+  val key_size : int
 end
 
 module StandardSuperblockParams : SUPERBLOCK_PARAMS
 
 val standard_mount_options : mount_options
 
-val read_superblock_params : (module Mirage_types_lwt.BLOCK with type t = 'a) -> 'a -> (module SUPERBLOCK_PARAMS) Lwt.t
+val read_superblock_params :
+  (module Mirage_types_lwt.BLOCK with type t = 'a) ->
+  'a ->
+  (module SUPERBLOCK_PARAMS) Lwt.t
 
-type deviceOpenMode = OpenExistingDevice | FormatEmptyDevice of int64
-module type S =
-  sig
-    type key
-    type value
-    type disk
-    type root
-    module Key :
-      sig
-        type t = key
-        val equal : t -> t -> bool
-        val hash : t -> int
-        val compare : t -> t -> int
-      end
-    module P : SUPERBLOCK_PARAMS
-    val key_of_cstruct : Cstruct.t -> key
-    val key_of_string : string -> key
-    val key_of_string_padded : string -> key
-    val cstruct_of_key : key -> Cstruct.t
-    val string_of_key : key -> string
-    val value_of_cstruct : Cstruct.t -> value
-    val value_of_string : string -> value
-    val value_equal : value -> value -> bool
-    val cstruct_of_value : value -> Cstruct.t
-    val string_of_value : value -> string
-    val next_key : key -> key
-    val is_tombstone : root -> value -> bool
-    val insert : root -> key -> value -> unit Lwt.t
-    val lookup : root -> key -> value option Lwt.t
-    val mem : root -> key -> bool Lwt.t
-    val flush : root -> int64 Lwt.t
-    val fstrim : root -> int64 Lwt.t
-    val live_trim : root -> int64 Lwt.t
-    val log_statistics : root -> unit
-    val search_range :
-      root -> key -> key -> (key -> value -> unit) -> unit Lwt.t
-    val iter :
-      root -> (key -> value -> unit) -> unit Lwt.t
-    val prepare_io : deviceOpenMode -> disk -> mount_options -> (root * int64) Lwt.t
+type deviceOpenMode =
+  | OpenExistingDevice
+  | FormatEmptyDevice of int64
+
+module type S = sig
+  type key
+
+  type value
+
+  type disk
+
+  type root
+
+  module Key : sig
+    type t = key
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+
+    val compare : t -> t -> int
   end
-module Make :
-  functor (B : EXTBLOCK) (P : SUPERBLOCK_PARAMS) -> (S with type disk = B.t)
+
+  module P : SUPERBLOCK_PARAMS
+
+  val key_of_cstruct : Cstruct.t -> key
+
+  val key_of_string : string -> key
+
+  val key_of_string_padded : string -> key
+
+  val cstruct_of_key : key -> Cstruct.t
+
+  val string_of_key : key -> string
+
+  val value_of_cstruct : Cstruct.t -> value
+
+  val value_of_string : string -> value
+
+  val value_equal : value -> value -> bool
+
+  val cstruct_of_value : value -> Cstruct.t
+
+  val string_of_value : value -> string
+
+  val next_key : key -> key
+
+  val is_tombstone : root -> value -> bool
+
+  val insert : root -> key -> value -> unit Lwt.t
+
+  val lookup : root -> key -> value option Lwt.t
+
+  val mem : root -> key -> bool Lwt.t
+
+  val flush : root -> int64 Lwt.t
+
+  val fstrim : root -> int64 Lwt.t
+
+  val live_trim : root -> int64 Lwt.t
+
+  val log_statistics : root -> unit
+
+  val search_range :
+    root -> key -> key -> (key -> value -> unit) -> unit Lwt.t
+
+  val iter : root -> (key -> value -> unit) -> unit Lwt.t
+
+  val prepare_io :
+    deviceOpenMode -> disk -> mount_options -> (root * int64) Lwt.t
+end
+
+module Make (B : EXTBLOCK) (P : SUPERBLOCK_PARAMS) : S with type disk = B.t
 
 type open_ret =
-    OPEN_RET : (module S with type root = 'a) * 'a * int64 -> open_ret
+  | OPEN_RET : (module S with type root = 'a) * 'a * int64 -> open_ret
 
 val open_for_reading :
-  (module EXTBLOCK with type t = 'a) ->
-  'a -> mount_options -> open_ret Lwt.t
-
+  (module EXTBLOCK with type t = 'a) -> 'a -> mount_options -> open_ret Lwt.t

--- a/src/wodan/wodan_btreemap.ml
+++ b/src/wodan/wodan_btreemap.ml
@@ -3,58 +3,95 @@ open Stdcompat
 (* include Btreemap *)
 
 (* a functional map, which we wrap in imperative style *)
-module FMap = Wodan_map_407.Make(String)
+module FMap = Wodan_map_407.Make (String)
 
-type 'a t = ('a FMap.t) ref
+type 'a t = 'a FMap.t ref
+
 exception AlreadyExists
 
 let create () = ref FMap.empty
+
 let length m = FMap.cardinal !m
+
 let is_empty m = !m = FMap.empty
+
 let clear m = m := FMap.empty
+
 let find_opt k m = FMap.find_opt k !m
+
 let mem k m = FMap.mem k !m
+
 let add k v m = m := FMap.add k v !m
-let map1 k f m =
-  m := FMap.update k f !m
+
+let map1 k f m = m := FMap.update k f !m
+
 let update k v m =
-  m := FMap.update k (function Some _ -> Some v | None -> raise Not_found) !m
+  m :=
+    FMap.update k
+      (function
+        | Some _ ->
+            Some v
+        | None ->
+            raise Not_found)
+      !m
+
 let xadd k v m =
-  m := FMap.update k (function Some _ -> raise AlreadyExists | None -> Some v) !m
-let remove k m =
-  m := FMap.remove k !m
-let iter f m = 
-  FMap.iter f !m
+  m :=
+    FMap.update k
+      (function
+        | Some _ ->
+            raise AlreadyExists
+        | None ->
+            Some v)
+      !m
+
+let remove k m = m := FMap.remove k !m
+
+let iter f m = FMap.iter f !m
+
 let iter_range start end_excl f m =
   try
-    FMap.to_seq_from start !m |>
-    Seq.iter (
-      fun (k, v) ->
-        if String.compare k end_excl < 0 then f k v else raise Exit)
+    FMap.to_seq_from start !m
+    |> Seq.iter (fun (k, v) ->
+           if String.compare k end_excl < 0 then f k v else raise Exit )
   with Exit -> ()
+
 let iter_inclusive_range start end_incl f m =
   try
-    FMap.to_seq_from start !m |>
-    Seq.iter (
-      fun (k, v) ->
-        if String.compare k end_incl <= 0 then f k v else raise Exit)
+    FMap.to_seq_from start !m
+    |> Seq.iter (fun (k, v) ->
+           if String.compare k end_incl <= 0 then f k v else raise Exit )
   with Exit -> ()
+
 let fold f m acc = FMap.fold f !m acc
+
 let exists f m = FMap.exists f !m
+
 let min_binding m = FMap.min_binding_opt !m
+
 let max_binding m = FMap.max_binding_opt !m
-let find_first_opt k m = FMap.find_first_opt (fun k' -> String.compare k k' <= 0) !m
-let find_last_opt k m = FMap.find_last_opt (fun k' -> String.compare k' k < 0) !m
+
+let find_first_opt k m =
+  FMap.find_first_opt (fun k' -> String.compare k k' <= 0) !m
+
+let find_last_opt k m =
+  FMap.find_last_opt (fun k' -> String.compare k' k < 0) !m
+
 let split_off_after k m =
   let m1, m2 = FMap.partition (fun k' _v -> String.compare k k' >= 0) !m in
-  m := m1; ref m2
+  m := m1;
+  ref m2
+
 let carve_inclusive_range start end_incl m =
-  let m1, m2 = FMap.partition (fun k _v ->
-      String.compare start k > 0
-      || String.compare k end_incl > 0) !m in
-  m := m1; ref m2
+  let m1, m2 =
+    FMap.partition
+      (fun k _v -> String.compare start k > 0 || String.compare k end_incl > 0)
+      !m
+  in
+  m := m1;
+  ref m2
+
 let swap m1 m2 =
   let m = !m1 in
   m1 := !m2;
   m2 := m
-

--- a/src/wodan/wodan_btreemap.mli
+++ b/src/wodan/wodan_btreemap.mli
@@ -1,29 +1,51 @@
 type 'a t
 
-val create: unit -> 'a t
-val length: 'a t -> int
-val is_empty: 'a t -> bool
-val clear: 'a t -> unit
-val find_opt: string -> 'a t -> 'a option
-val mem: string -> 'a t -> bool
-val add: string -> 'a -> 'a t -> unit
-(* Map a single value through a function in place *)
-val map1: string -> ('a option -> 'a option) -> 'a t -> unit
-(* Like add, but a value must already exist *)
-val update: string -> 'a -> 'a t -> unit
-(* Like add, but a value cannot already exist *)
-val xadd: string -> 'a -> 'a t -> unit
-val remove: string -> 'a t -> unit
-val iter: (string -> 'a -> unit) -> 'a t -> unit
-val iter_range: string -> string -> (string -> 'a -> unit) -> 'a t -> unit
-val iter_inclusive_range: string -> string -> (string -> 'a -> unit) -> 'a t -> unit
-val carve_inclusive_range: string -> string -> 'a t -> 'a t
-val fold: (string -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
-val exists: (string -> 'a -> bool) -> 'a t -> bool
-val min_binding: 'a t -> (string * 'a) option
-val max_binding: 'a t -> (string * 'a) option
-val find_first_opt: string -> 'a t -> (string * 'a) option
-val find_last_opt: string -> 'a t -> (string * 'a) option
-val split_off_after: string -> 'a t -> 'a t
-val swap: 'a t -> 'a t -> unit
+val create : unit -> 'a t
 
+val length : 'a t -> int
+
+val is_empty : 'a t -> bool
+
+val clear : 'a t -> unit
+
+val find_opt : string -> 'a t -> 'a option
+
+val mem : string -> 'a t -> bool
+
+val add : string -> 'a -> 'a t -> unit
+
+(* Map a single value through a function in place *)
+val map1 : string -> ('a option -> 'a option) -> 'a t -> unit
+
+(* Like add, but a value must already exist *)
+val update : string -> 'a -> 'a t -> unit
+
+(* Like add, but a value cannot already exist *)
+val xadd : string -> 'a -> 'a t -> unit
+
+val remove : string -> 'a t -> unit
+
+val iter : (string -> 'a -> unit) -> 'a t -> unit
+
+val iter_range : string -> string -> (string -> 'a -> unit) -> 'a t -> unit
+
+val iter_inclusive_range :
+  string -> string -> (string -> 'a -> unit) -> 'a t -> unit
+
+val carve_inclusive_range : string -> string -> 'a t -> 'a t
+
+val fold : (string -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+
+val exists : (string -> 'a -> bool) -> 'a t -> bool
+
+val min_binding : 'a t -> (string * 'a) option
+
+val max_binding : 'a t -> (string * 'a) option
+
+val find_first_opt : string -> 'a t -> (string * 'a) option
+
+val find_last_opt : string -> 'a t -> (string * 'a) option
+
+val split_off_after : string -> 'a t -> 'a t
+
+val swap : 'a t -> 'a t -> unit

--- a/src/wodan/wodan_crc32c.ml
+++ b/src/wodan/wodan_crc32c.ml
@@ -1,30 +1,27 @@
 (* Copyright (c) 2016-2017, Gabriel de Perthuis - ISC licensed *)
 
-let (~~~) = Int32.lognot
+let ( ~~~ ) = Int32.lognot
 
 (* XXX x64 only *)
 let optint_sign = Optint.of_int 0x8000_0000
 
 let optint_of_uint32 i =
-  if i < 0l then
-    Optint.(logor optint_sign @@ of_int32 @@ Int32.neg i)
+  if i < 0l then Optint.(logor optint_sign @@ of_int32 @@ Int32.neg i)
   else Optint.of_int32 i
 
-let optint_to_uint32 i =
-  Optint.to_int32 i
+let optint_to_uint32 i = Optint.to_int32 i
 
+let cstruct ?(crc = 0l) cstr =
+  optint_to_uint32
+  @@ Checkseum.Crc32c.digest_bigstring (Cstruct.to_bigarray cstr) 0
+       (Cstruct.len cstr) (optint_of_uint32 crc)
 
-let cstruct ?(crc=0l) cstr =
-  optint_to_uint32 @@ Checkseum.Crc32c.digest_bigstring (Cstruct.to_bigarray cstr) 0 (Cstruct.len cstr) (optint_of_uint32 crc)
-
-let cstruct_valid str =
-  ~~~(cstruct str) = 0l
+let cstruct_valid str = ~~~(cstruct str) = 0l
 
 (*$T cstruct_reset
 let cstr = Cstruct.of_string "123456789...." in begin cstruct_reset cstr; cstruct_valid cstr end
 *)
 let cstruct_reset str =
-  let sublen = (Cstruct.len str) - 4 in
+  let sublen = Cstruct.len str - 4 in
   let crc = cstruct (Cstruct.sub str 0 sublen) in
   Cstruct.LE.set_uint32 str sublen ~~~crc
-

--- a/src/wodan/wodan_crc32c.mli
+++ b/src/wodan/wodan_crc32c.mli
@@ -1,14 +1,13 @@
 (* Copyright 2014 Citrix - ISC licensed *)
 
-val cstruct: ?crc:int32 -> Cstruct.t -> int32
+val cstruct : ?crc:int32 -> Cstruct.t -> int32
 (** [cstruct ?crc buf] computes the CRC32C of [buf] with optional
     initial value [crc] *)
 
-val cstruct_valid: Cstruct.t -> bool
+val cstruct_valid : Cstruct.t -> bool
 (** [cstruct_valid cstruct] returns whether the CRC32C of cstruct is
     0xffffffffl *)
 
-val cstruct_reset: Cstruct.t -> unit
+val cstruct_reset : Cstruct.t -> unit
 (** [cstruct_reset cstruct] rewrites the last four bytes of
     cstruct so that [cstruct_valid cstruct] is true *)
-


### PR DESCRIPTION
As discussed with @g2p.
This uses the following configuration (to be discussed if necessary) : 
```
break-cases=all
break-infix=fit-or-vertical
break-separators=after-and-docked
field-space=loose
margin=79
parens-tuple=always
sequence-style=terminator
type-decl=sparse

```
It would be nice to merge this soon so that other PRs can be made too.