### PR TITLE
Remove `@@` operators

### DIFF
--- a/irmin-tests/test_wodan.ml
+++ b/irmin-tests/test_wodan.ml
@@ -20,7 +20,7 @@ open Irmin_test
 module BlockCon = struct
   include Ramdisk
   let connect name = Ramdisk.connect ~name
-  let discard _ _ _ = Lwt.return @@ Ok ()
+  let discard _ _ _ = Lwt.return (Ok ())
 end
 
 module DB_ram = Wodan_irmin.DB_BUILDER(BlockCon)(Wodan.StandardSuperblockParams)

--- a/src/wodan-irmin/bin/wodan_git_import.ml
+++ b/src/wodan-irmin/bin/wodan_git_import.ml
@@ -32,7 +32,7 @@ let wodan_config = Wodan_irmin.config ~path:"git-import.img" ~create:true ()
 
 module Git_S = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
 
-(*let git_config = Irmin_git.config @@ Sys.getcwd ()*)
+(*let git_config = Irmin_git.config (Sys.getcwd ())*)
 (* Use a repo that doesn't have submodules *)
 let git_config = Irmin_git.config Sys.argv.(1)
 
@@ -64,9 +64,7 @@ let run () =
   Lwt.return_unit
 
 let () =
-  Logs.set_reporter @@ Logs.format_reporter ();
-  Logs.set_level @@ Some Logs.Info;
-  Logs.info
-  @@ fun m ->
-  m "Pwd %s" @@ Sys.getcwd ();
-  Lwt_main.run @@ run ()
+  Logs.set_reporter (Logs.format_reporter ());
+  Logs.set_level (Some Logs.Info);
+  Logs.info (fun m -> m "Pwd %s" (Sys.getcwd ()));
+  Lwt_main.run (run ())

--- a/src/wodan-irmin/bin/wodan_irmin_cli.ml
+++ b/src/wodan-irmin/bin/wodan_irmin_cli.ml
@@ -22,7 +22,7 @@ module RamBlockCon = struct
 
   let connect name = Ramdisk.connect ~name
 
-  let discard _ _ _ = Lwt.return @@ Ok ()
+  let discard _ _ _ = Lwt.return (Ok ())
 end
 
 module DB_ram =

--- a/src/wodan-unix/wodanc.ml
+++ b/src/wodan-unix/wodanc.ml
@@ -243,4 +243,4 @@ let cmds =
     fuzz_cmd;
     help_cmd ]
 
-let () = Term.(exit @@ eval_choice default_cmd cmds)
+let () = Term.(exit (eval_choice default_cmd cmds))

--- a/src/wodan/wodan_crc32c.ml
+++ b/src/wodan/wodan_crc32c.ml
@@ -23,15 +23,15 @@ let ( ~~~ ) = Int32.lognot
 let optint_sign = Optint.of_int 0x8000_0000
 
 let optint_of_uint32 i =
-  if i < 0l then Optint.(logor optint_sign @@ of_int32 @@ Int32.neg i)
+  if i < 0l then Optint.(logor optint_sign (of_int32 (Int32.neg i)))
   else Optint.of_int32 i
 
 let optint_to_uint32 i = Optint.to_int32 i
 
 let cstruct ?(crc = 0l) cstr =
   optint_to_uint32
-  @@ Checkseum.Crc32c.digest_bigstring (Cstruct.to_bigarray cstr) 0
-       (Cstruct.len cstr) (optint_of_uint32 crc)
+    (Checkseum.Crc32c.digest_bigstring (Cstruct.to_bigarray cstr) 0
+       (Cstruct.len cstr) (optint_of_uint32 crc))
 
 let cstruct_valid str = ~~~(cstruct str) = 0l
 


### PR DESCRIPTION
As suggested in #48, `@@` operators are preventing some compiler optimizations.
They are widely used in Wodan, here is a PR to remove them.
There might be places where it's fine to keep them though (or maybe we don't want to remove them at all), let's discuss.