### PR TITLE
make deps: handle dependencies of vendored packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script:
-- export PINS="$(for op in vendor/*/*.opam; do echo "$op" |sed -re 's#(vendor/.*/)(.*)\.opam#\2.dev:\1#'; done)"
+- export PINS="$(for op in vendor/*/*.opam; do echo "$op" |sed -re 's#(vendor/.*/)(.*)\.opam#\2.dev:\1#'; done |xargs)"
 - bash -ex .travis-opam.sh
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script:
-- export PINS="$(for d in $(command ls vendor); do echo -n "$d.dev:vendor/$d/ "; done)"
+- export PINS="$(for op in vendor/*/*.opam; do echo "$op" |sed -re 's#(vendor/.*/)(.*)\.opam#\2.dev:\1#'; done)"
 - bash -ex .travis-opam.sh
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script:
-- export PINS="$(for op in vendor/*/*.opam; do echo "$op" |sed -re 's#(vendor/.*/)(.*)\.opam#\2.dev:\1#'; done |xargs)"
+- export PINS="$({ echo wodan.dev:.; for op in vendor/*/*.opam; do echo "$op" |sed -re 's#(vendor/.*/)(.*)\.opam#\2.dev:\1#'; done; } |xargs)"
 - bash -ex .travis-opam.sh
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: c
 sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
+script:
+- export PINS="$(for d in $(command ls vendor); do echo "$d.dev:vendor/$d/"; done)"
+- bash -ex .travis-opam.sh
 env:
   global:
   - ALCOTEST_SHOW_ERRORS=1
-  - PINS="wodan.dev:. irmin.dev:vendor/irmin irmin-chunk.dev:vendor/irmin irmin-git.dev:vendor/irmin irmin-unix:vendor/irmin irmin-http:vendor/irmin irmin-test:vendor/irmin irmin-fs:vendor/irmin irmin-mem:vendor/irmin"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script:
-- export PINS="$(for d in $(command ls vendor); do echo "$d.dev:vendor/$d/"; done)"
+- export PINS="$(for d in $(command ls vendor); do echo -n "$d.dev:vendor/$d/ "; done)"
 - bash -ex .travis-opam.sh
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ build:
 
 deps:
 	git submodule update --init --recursive
-	opam install --deps-only -y .
+	opam install --deps-only -y . vendor/*/
+	dune external-lib-deps --missing @@default
 
 sync:
 	git submodule sync --recursive

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ build:
 deps:
 	git submodule update --init --recursive
 	opam install --deps-only -y . vendor/*/
-	dune external-lib-deps --missing @@default
 
 sync:
 	git submodule sync --recursive


### PR DESCRIPTION
Also drop vendored stuff that was only useful as a dependency,
and forks that are now fixed upstream (ocaml-yaml).

Preparation for PR #47.