### PR TITLE
Enforce formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script:
-- export PINS="$({ echo wodan.dev:.; for op in vendor/*/*.opam; do echo "$op" |sed -re 's#(vendor/.*/)(.*)\.opam#\2.dev:\1#'; done; } |xargs)"
+- export PINS="$({ echo wodan.dev:. ocamlformat:https://github.com/ocaml-ppx/ocamlformat.git#2de7c5f; for op in vendor/*/*.opam; do echo "$op" |sed -re 's#(vendor/.*/)(.*)\.opam#\2.dev:\1#'; done; } |xargs)"
 - bash -ex .travis-opam.sh
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ sync:
 	git submodule update --init --recursive
 
 ocamlformat:
-	# Use the master version of ocamlformat for matching results
-	git ls-files -- 'src/*.ml' 'src/*.mli' |grep -v 407 |xargs ocamlformat --inplace
+	# Use 2de7c5f version of ocamlformat
+	dune build @fmt --auto-promote
 
 fuzz:
 	dune build src/wodan-unix/wodanc.exe

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
-(lang dune 1.3)
+(lang dune 1.7)
 (name wodan)
+(using fmt 1.1)

--- a/examples/solo5-irmin/config.ml
+++ b/examples/solo5-irmin/config.ml
@@ -1,6 +1,7 @@
 open Mirage
 
 let stack = generic_stackv4 default_network
+
 (* set ~tls to false to get a plain-http server *)
 let http_srv = http_server @@ conduit_direct ~tls:false stack
 
@@ -9,17 +10,17 @@ let http_port =
   Key.(create "http_port" Arg.(opt int 8080 doc))
 
 let main =
-  let packages = [
-      package "uri";
+  let packages =
+    [ package "uri";
       package "wodan-irmin";
-      package ~sublibs:["ocaml"] "checkseum";
-  ] in
-  let keys = List.map Key.abstract [ http_port ] in
-  foreign
-    ~packages ~keys
-    "Dispatch.HTTP" (time @-> pclock @-> http @-> block @-> job)
+      package ~sublibs:["ocaml"] "checkseum" ]
+  in
+  let keys = List.map Key.abstract [http_port] in
+  foreign ~packages ~keys "Dispatch.HTTP"
+    (time @-> pclock @-> http @-> block @-> job)
 
 let img = block_of_file "disk.img"
 
 let () =
-  register "http-irmin" [main $ default_time $ default_posix_clock $ http_srv $ img]
+  register "http-irmin"
+    [main $ default_time $ default_posix_clock $ http_srv $ img]

--- a/examples/solo5-irmin/config.ml
+++ b/examples/solo5-irmin/config.ml
@@ -3,7 +3,7 @@ open Mirage
 let stack = generic_stackv4 default_network
 
 (* set ~tls to false to get a plain-http server *)
-let http_srv = http_server @@ conduit_direct ~tls:false stack
+let http_srv = http_server (conduit_direct ~tls:false stack)
 
 let http_port =
   let doc = Key.Arg.info ~doc:"Listening HTTP port." ["http"] in

--- a/examples/solo5-irmin/dispatch.ml
+++ b/examples/solo5-irmin/dispatch.ml
@@ -14,7 +14,7 @@ module BlockCon = struct
 
   (* from mirage-block-solo5 *)
 
-  let discard _ _ _ = Lwt.return @@ Ok ()
+  let discard _ _ _ = Lwt.return (Ok ())
 end
 
 module DB = Wodan_irmin.DB_BUILDER (BlockCon) (Wodan.StandardSuperblockParams)
@@ -52,7 +52,7 @@ module Dispatch (S : HTTP) = struct
     | str
       when str.[0] = '/' ->
         let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
-        let head = String.sub str 1 @@ pred @@ String.length str in
+        let head = String.sub str 1 (pred (String.length str)) in
         let head = Irmin.Type.of_string Wodan_Git_KV.Commit.Hash.t head in
         let head =
           match head with
@@ -112,7 +112,7 @@ struct
       Wodan_Git_KV.Repo.v store_conf
       >>= fun repo ->
       Http_log.info (fun f -> f "repo ready");
-      http tcp @@ D.serve (D.dispatcher repo)
+      http tcp (D.serve (D.dispatcher repo))
     in
     Lwt.join [http]
 end

--- a/examples/solo5-irmin/dispatch.ml
+++ b/examples/solo5-irmin/dispatch.ml
@@ -6,56 +6,78 @@ module type HTTP = Cohttp_lwt.S.Server
 
 (* Logging *)
 let http_src = Logs.Src.create "http" ~doc:"HTTP server"
+
 module Http_log = (val Logs.src_log http_src : Logs.LOG)
 
 module BlockCon = struct
-  include Block (* from mirage-block-solo5 *)
+  include Block
+
+  (* from mirage-block-solo5 *)
+
   let discard _ _ _ = Lwt.return @@ Ok ()
 end
 
-module DB = Wodan_irmin.DB_BUILDER
-  (BlockCon)(Wodan.StandardSuperblockParams)
-module Wodan_Git_KV = Wodan_irmin.KV_git(DB)
+module DB = Wodan_irmin.DB_BUILDER (BlockCon) (Wodan.StandardSuperblockParams)
+module Wodan_Git_KV = Wodan_irmin.KV_git (DB)
 
-module Dispatch (S: HTTP) = struct
-
+module Dispatch (S : HTTP) = struct
   (* given a URI, find the appropriate file,
    * and construct a response with its contents. *)
   let rec dispatcher repo uri =
     match Uri.path uri with
-    | "" | "/" -> dispatcher repo (Uri.with_path uri "README.md")
+    | ""
+     |"/" ->
+        dispatcher repo (Uri.with_path uri "README.md")
     | "/README.md" ->
-      let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
-      Wodan_Git_KV.Head.list repo >>= fun commits ->
-      List.iter (fun k ->
-          Logs.debug (fun m -> m "Head %a" Wodan_Git_KV.Commit.pp_hash k)) commits;
-      Wodan_Git_KV.master repo >>= fun t ->
-      Wodan_Git_KV.list t [] >>= fun li ->
-      List.iter (fun (k, _v) ->
-          Logs.debug (fun m -> m "List %s" k)) li;
-      Lwt.catch (fun () -> Wodan_Git_KV.get t ["counter-wodan"; "README.md"]) (fun err -> Logs.debug (fun m -> m "L %a" Fmt.exn err); raise err)
-      >>= fun contents ->
-      let body = Irmin.Type.to_string Wodan_Git_KV.contents_t contents in
-      S.respond_string ~status:`OK ~body ~headers ()
-    |str when str.[0] = '/' ->
-      let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
-      let head = String.sub str 1 @@ pred @@ String.length str in
-      let head = Irmin.Type.of_string Wodan_Git_KV.Commit.Hash.t head in
-      let head = match head with
-        |Error _ -> assert false
-        |Ok x -> x
-      in
-      Wodan_Git_KV.Commit.of_hash repo head >>= fun commit ->
-      let commit = match commit with
-        |None -> assert false
-        |Some x -> x
-      in
-      Wodan_Git_KV.of_commit commit >>= fun t ->
-      Wodan_Git_KV.get t ["README.md"] >>= fun t ->
-      let body = Irmin.Type.to_string Wodan_Git_KV.contents_t t in
-      S.respond_string ~status:`OK ~body ~headers ()
+        let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
+        Wodan_Git_KV.Head.list repo
+        >>= fun commits ->
+        List.iter
+          (fun k ->
+            Logs.debug (fun m -> m "Head %a" Wodan_Git_KV.Commit.pp_hash k) )
+          commits;
+        Wodan_Git_KV.master repo
+        >>= fun t ->
+        Wodan_Git_KV.list t []
+        >>= fun li ->
+        List.iter (fun (k, _v) -> Logs.debug (fun m -> m "List %s" k)) li;
+        Lwt.catch
+          (fun () -> Wodan_Git_KV.get t ["counter-wodan"; "README.md"])
+          (fun err ->
+            Logs.debug (fun m -> m "L %a" Fmt.exn err);
+            raise err )
+        >>= fun contents ->
+        let body = Irmin.Type.to_string Wodan_Git_KV.contents_t contents in
+        S.respond_string ~status:`OK ~body ~headers ()
+    | str
+      when str.[0] = '/' ->
+        let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
+        let head = String.sub str 1 @@ pred @@ String.length str in
+        let head = Irmin.Type.of_string Wodan_Git_KV.Commit.Hash.t head in
+        let head =
+          match head with
+          | Error _ ->
+              assert false
+          | Ok x ->
+              x
+        in
+        Wodan_Git_KV.Commit.of_hash repo head
+        >>= fun commit ->
+        let commit =
+          match commit with
+          | None ->
+              assert false
+          | Some x ->
+              x
+        in
+        Wodan_Git_KV.of_commit commit
+        >>= fun t ->
+        Wodan_Git_KV.get t ["README.md"]
+        >>= fun t ->
+        let body = Irmin.Type.to_string Wodan_Git_KV.contents_t t in
+        S.respond_string ~status:`OK ~body ~headers ()
     | _ ->
-      S.respond_not_found ()
+        S.respond_not_found ()
 
   let serve dispatch =
     let callback (_, cid) request _body =
@@ -64,27 +86,27 @@ module Dispatch (S: HTTP) = struct
       Http_log.info (fun f -> f "[%s] serving %s." cid (Uri.to_string uri));
       dispatch uri
     in
-    let conn_closed (_,cid) =
+    let conn_closed (_, cid) =
       let cid = Cohttp.Connection.to_string cid in
-      Http_log.info (fun f -> f "[%s] closing" cid);
+      Http_log.info (fun f -> f "[%s] closing" cid)
     in
     S.make ~conn_closed ~callback ()
-
 end
 
 module HTTP
-    (Time: Mirage_types_lwt.TIME)
-    (Pclock: Mirage_types.PCLOCK)
-    (Http: HTTP)
-    (B: BLOCK)
-= struct
-
-  module D = Dispatch(Http)
+    (Time : Mirage_types_lwt.TIME)
+    (Pclock : Mirage_types.PCLOCK)
+    (Http : HTTP)
+    (B : BLOCK) =
+struct
+  module D = Dispatch (Http)
 
   let start _time _clock http block =
     let http_port = Key_gen.http_port () in
     let tcp = `TCP http_port in
-    let store_conf = Wodan_irmin.config ~path:"../git-import.img" ~create:false () in
+    let store_conf =
+      Wodan_irmin.config ~path:"../git-import.img" ~create:false ()
+    in
     let http =
       Http_log.info (fun f -> f "listening on %d/TCP" http_port);
       Wodan_Git_KV.Repo.v store_conf
@@ -92,6 +114,5 @@ module HTTP
       Http_log.info (fun f -> f "repo ready");
       http tcp @@ D.serve (D.dispatcher repo)
     in
-    Lwt.join [ http ]
-
+    Lwt.join [http]
 end

--- a/examples/solo5-irmin/dispatch.ml
+++ b/examples/solo5-irmin/dispatch.ml
@@ -10,9 +10,8 @@ let http_src = Logs.Src.create "http" ~doc:"HTTP server"
 module Http_log = (val Logs.src_log http_src : Logs.LOG)
 
 module BlockCon = struct
-  include Block
-
   (* from mirage-block-solo5 *)
+  include Block
 
   let discard _ _ _ = Lwt.return (Ok ())
 end

--- a/examples/solo5-server/config.ml
+++ b/examples/solo5-server/config.ml
@@ -3,7 +3,7 @@ open Mirage
 let stack = generic_stackv4 default_network
 
 (* set ~tls to false to get a plain-http server *)
-let http_srv = http_server @@ conduit_direct ~tls:false stack
+let http_srv = http_server (conduit_direct ~tls:false stack)
 
 let http_port =
   let doc = Key.Arg.info ~doc:"Listening HTTP port." ["http"] in

--- a/examples/solo5-server/config.ml
+++ b/examples/solo5-server/config.ml
@@ -1,6 +1,7 @@
 open Mirage
 
 let stack = generic_stackv4 default_network
+
 (* set ~tls to false to get a plain-http server *)
 let http_srv = http_server @@ conduit_direct ~tls:false stack
 
@@ -9,18 +10,18 @@ let http_port =
   Key.(create "http_port" Arg.(opt int 8080 doc))
 
 let main =
-  let packages = [
-      package "uri";
+  let packages =
+    [ package "uri";
       package "wodan";
       package "hex";
-      package ~sublibs:["ocaml"] "checkseum";
-  ] in
-  let keys = List.map Key.abstract [ http_port ] in
-  foreign
-    ~packages ~keys
-    "Dispatch.HTTP" (time @-> pclock @-> http @-> block @-> job)
+      package ~sublibs:["ocaml"] "checkseum" ]
+  in
+  let keys = List.map Key.abstract [http_port] in
+  foreign ~packages ~keys "Dispatch.HTTP"
+    (time @-> pclock @-> http @-> block @-> job)
 
 let img = block_of_file "disk.img"
 
 let () =
-  register "http-server" [main $ default_time $ default_posix_clock $ http_srv $ img]
+  register "http-server"
+    [main $ default_time $ default_posix_clock $ http_srv $ img]

--- a/examples/solo5-server/dispatch.ml
+++ b/examples/solo5-server/dispatch.ml
@@ -18,12 +18,12 @@ module Dispatch (Store : Wodan.S) (S : HTTP) = struct
     Store.lookup store key
     >>= function
     | Some counter ->
-        let c = Int64.of_string @@ Store.string_of_value counter in
+        let c = Int64.of_string (Store.string_of_value counter) in
         let c = Int64.succ c in
-        Store.insert store key @@ Store.value_of_string @@ Int64.to_string c
+        Store.insert store key (Store.value_of_string (Int64.to_string c))
         >>= fun () -> Lwt.return c
     | None ->
-        Store.insert store key @@ Store.value_of_string "1"
+        Store.insert store key (Store.value_of_string "1")
         >>= fun () -> Lwt.return 1L
 
   (* given a URI, find the appropriate file,
@@ -62,8 +62,8 @@ module Dispatch (Store : Wodan.S) (S : HTTP) = struct
     | str
       when str.[0] = '/' -> (
         let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
-        let head = String.sub str 1 @@ pred @@ String.length str in
-        let head = Hex.to_string @@ `Hex head in
+        let head = String.sub str 1 (pred (String.length str)) in
+        let head = Hex.to_string (`Hex head) in
         let head = Store.key_of_string head in
         Store.lookup store head
         >>= function
@@ -113,7 +113,7 @@ struct
       >>= fun (store, _) ->
       Lwt.async (fun () -> periodic_flush store);
       Http_log.info (fun f -> f "store done");
-      http tcp @@ D.serve (D.dispatcher store)
+      http tcp (D.serve (D.dispatcher store))
     in
     Lwt.join [http]
 end

--- a/examples/solo5-server/dispatch.ml
+++ b/examples/solo5-server/dispatch.ml
@@ -6,35 +6,40 @@ module type HTTP = Cohttp_lwt.S.Server
 
 (* Logging *)
 let http_src = Logs.Src.create "http" ~doc:"HTTP server"
+
 module Http_log = (val Logs.src_log http_src : Logs.LOG)
 
-module Dispatch (Store: Wodan.S) (S: HTTP) = struct
-
+module Dispatch (Store : Wodan.S) (S : HTTP) = struct
   let failf fmt = Fmt.kstrf Lwt.fail_with fmt
 
   let key = Store.key_of_string "12345678901234567890"
 
   let next_camel store =
-        Store.lookup store key >>= function
-            Some counter ->
-              let c = Int64.of_string @@ Store.string_of_value counter in
-              let c = Int64.succ c in
-              Store.insert store key @@ Store.value_of_string @@ Int64.to_string c >>= fun () ->
-              Lwt.return c
-            | None ->
-              Store.insert store key @@ Store.value_of_string "1" >>= fun () ->
-              Lwt.return 1L
+    Store.lookup store key
+    >>= function
+    | Some counter ->
+        let c = Int64.of_string @@ Store.string_of_value counter in
+        let c = Int64.succ c in
+        Store.insert store key @@ Store.value_of_string @@ Int64.to_string c
+        >>= fun () -> Lwt.return c
+    | None ->
+        Store.insert store key @@ Store.value_of_string "1"
+        >>= fun () -> Lwt.return 1L
 
   (* given a URI, find the appropriate file,
    * and construct a response with its contents. *)
   let rec dispatcher store uri =
     match Uri.path uri with
-    | "" | "/" -> dispatcher store (Uri.with_path uri "index.html")
+    | ""
+     |"/" ->
+        dispatcher store (Uri.with_path uri "index.html")
     | "/index.html" ->
-      let headers = Cohttp.Header.init_with "Content-Type" "text/html"
-      in
-      next_camel store >>= fun counter ->
-      let body = Fmt.strf {html|<html>
+        let headers = Cohttp.Header.init_with "Content-Type" "text/html" in
+        next_camel store
+        >>= fun counter ->
+        let body =
+          Fmt.strf
+            {html|<html>
 <body>
 <pre>
                      ,,__
@@ -50,21 +55,25 @@ module Dispatch (Store: Wodan.S) (S: HTTP) = struct
        %Ld camels served!
 </pre>
 </body></html>
-|html} (counter)
-      in
-      S.respond_string ~status:`OK ~body ~headers ()
-    |str when str.[0] = '/' ->
-      let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
-      let head = String.sub str 1 @@ pred @@ String.length str in
-      let head = Hex.to_string @@ `Hex head in
-      let head = Store.key_of_string head in
-      Store.lookup store head >>= function
-      |None -> assert false
-      |Some x ->
-        let x = Store.string_of_value x in
-      S.respond_string ~status:`OK ~body:x ~headers ()
-    | _ ->
-      S.respond_not_found ()
+|html}
+            counter
+        in
+        S.respond_string ~status:`OK ~body ~headers ()
+    | str
+      when str.[0] = '/' -> (
+        let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
+        let head = String.sub str 1 @@ pred @@ String.length str in
+        let head = Hex.to_string @@ `Hex head in
+        let head = Store.key_of_string head in
+        Store.lookup store head
+        >>= function
+        | None ->
+            assert false
+        | Some x ->
+            let x = Store.string_of_value x in
+            S.respond_string ~status:`OK ~body:x ~headers ()
+        | _ ->
+            S.respond_not_found () )
 
   let serve dispatch =
     let callback (_, cid) request _body =
@@ -73,44 +82,38 @@ module Dispatch (Store: Wodan.S) (S: HTTP) = struct
       Http_log.info (fun f -> f "[%s] serving %s." cid (Uri.to_string uri));
       dispatch uri
     in
-    let conn_closed (_,cid) =
+    let conn_closed (_, cid) =
       let cid = Cohttp.Connection.to_string cid in
-      Http_log.info (fun f -> f "[%s] closing" cid);
+      Http_log.info (fun f -> f "[%s] closing" cid)
     in
     S.make ~conn_closed ~callback ()
-
 end
 
 module HTTP
-    (Time: Mirage_types_lwt.TIME)
-    (Pclock: Mirage_types.PCLOCK)
-    (Http: HTTP)
-    (B: BLOCK)
-= struct
-
-  module B = Wodan.BlockCompat(B)
-
-  module Store = Wodan.Make(B)(Wodan.StandardSuperblockParams)
-  module D = Dispatch(Store)(Http)
+    (Time : Mirage_types_lwt.TIME)
+    (Pclock : Mirage_types.PCLOCK)
+    (Http : HTTP)
+    (B : BLOCK) =
+struct
+  module B = Wodan.BlockCompat (B)
+  module Store = Wodan.Make (B) (Wodan.StandardSuperblockParams)
+  module D = Dispatch (Store) (Http)
 
   let rec periodic_flush store =
     Time.sleep_ns 30_000_000_000L
-    >>= fun () ->
-    Store.flush store
-    >>= fun _gen ->
-    periodic_flush store
+    >>= fun () -> Store.flush store >>= fun _gen -> periodic_flush store
 
   let start _time _clock http block =
     let http_port = Key_gen.http_port () in
     let tcp = `TCP http_port in
     let http =
       Http_log.info (fun f -> f "listening on %d/TCP" http_port);
-      Store.prepare_io Wodan.OpenExistingDevice block Wodan.standard_mount_options
+      Store.prepare_io Wodan.OpenExistingDevice block
+        Wodan.standard_mount_options
       >>= fun (store, _) ->
       Lwt.async (fun () -> periodic_flush store);
       Http_log.info (fun f -> f "store done");
       http tcp @@ D.serve (D.dispatcher store)
     in
-    Lwt.join [ http ]
-
+    Lwt.join [http]
 end

--- a/examples/solo5-unikernel/config.ml
+++ b/examples/solo5-unikernel/config.ml
@@ -1,6 +1,7 @@
 open Mirage
 
 let stack = generic_stackv4 default_network
+
 (* set ~tls to false to get a plain-http server *)
 let http_srv = http_server @@ conduit_direct ~tls:false stack
 
@@ -9,15 +10,12 @@ let http_port =
   Key.(create "http_port" Arg.(opt int 8080 doc))
 
 let main =
-  let packages = [
-      package "uri";
-      package "wodan";
-      package ~sublibs:["ocaml"] "checkseum";
-  ] in
-  let keys = List.map Key.abstract [ http_port ] in
-  foreign
-    ~packages ~keys
-    "Dispatch.HTTP" (time @-> pclock @-> http @-> block @-> job)
+  let packages =
+    [package "uri"; package "wodan"; package ~sublibs:["ocaml"] "checkseum"]
+  in
+  let keys = List.map Key.abstract [http_port] in
+  foreign ~packages ~keys "Dispatch.HTTP"
+    (time @-> pclock @-> http @-> block @-> job)
 
 let img = block_of_file "disk.img"
 

--- a/examples/solo5-unikernel/config.ml
+++ b/examples/solo5-unikernel/config.ml
@@ -3,7 +3,7 @@ open Mirage
 let stack = generic_stackv4 default_network
 
 (* set ~tls to false to get a plain-http server *)
-let http_srv = http_server @@ conduit_direct ~tls:false stack
+let http_srv = http_server (conduit_direct ~tls:false stack)
 
 let http_port =
   let doc = Key.Arg.info ~doc:"Listening HTTP port." ["http"] in

--- a/examples/solo5-unikernel/dispatch.ml
+++ b/examples/solo5-unikernel/dispatch.ml
@@ -18,12 +18,12 @@ module Dispatch (Store : Wodan.S) (S : HTTP) = struct
     Store.lookup store key
     >>= function
     | Some counter ->
-        let c = Int64.of_string @@ Store.string_of_value counter in
+        let c = Int64.of_string (Store.string_of_value counter) in
         let c = Int64.succ c in
-        Store.insert store key @@ Store.value_of_string @@ Int64.to_string c
+        Store.insert store key (Store.value_of_string (Int64.to_string c))
         >>= fun () -> Lwt.return c
     | None ->
-        Store.insert store key @@ Store.value_of_string "1"
+        Store.insert store key (Store.value_of_string "1")
         >>= fun () -> Lwt.return 1L
 
   (* given a URI, find the appropriate file,
@@ -100,7 +100,7 @@ struct
       >>= fun (store, _) ->
       Lwt.async (fun () -> periodic_flush store);
       Http_log.info (fun f -> f "store done");
-      http tcp @@ D.serve (D.dispatcher store)
+      http tcp (D.serve (D.dispatcher store))
     in
     Lwt.join [http]
 end

--- a/examples/solo5-unikernel/dispatch.ml
+++ b/examples/solo5-unikernel/dispatch.ml
@@ -6,35 +6,40 @@ module type HTTP = Cohttp_lwt.S.Server
 
 (* Logging *)
 let http_src = Logs.Src.create "http" ~doc:"HTTP server"
+
 module Http_log = (val Logs.src_log http_src : Logs.LOG)
 
-module Dispatch (Store: Wodan.S) (S: HTTP) = struct
-
+module Dispatch (Store : Wodan.S) (S : HTTP) = struct
   let failf fmt = Fmt.kstrf Lwt.fail_with fmt
 
   let key = Store.key_of_string "12345678901234567890"
 
   let next_camel store =
-        Store.lookup store key >>= function
-            Some counter ->
-              let c = Int64.of_string @@ Store.string_of_value counter in
-              let c = Int64.succ c in
-              Store.insert store key @@ Store.value_of_string @@ Int64.to_string c >>= fun () ->
-              Lwt.return c
-            | None ->
-              Store.insert store key @@ Store.value_of_string "1" >>= fun () ->
-              Lwt.return 1L
+    Store.lookup store key
+    >>= function
+    | Some counter ->
+        let c = Int64.of_string @@ Store.string_of_value counter in
+        let c = Int64.succ c in
+        Store.insert store key @@ Store.value_of_string @@ Int64.to_string c
+        >>= fun () -> Lwt.return c
+    | None ->
+        Store.insert store key @@ Store.value_of_string "1"
+        >>= fun () -> Lwt.return 1L
 
   (* given a URI, find the appropriate file,
    * and construct a response with its contents. *)
   let rec dispatcher store uri =
     match Uri.path uri with
-    | "" | "/" -> dispatcher store (Uri.with_path uri "index.html")
+    | ""
+     |"/" ->
+        dispatcher store (Uri.with_path uri "index.html")
     | "/index.html" ->
-      let headers = Cohttp.Header.init_with "Content-Type" "text/html"
-      in
-      next_camel store >>= fun counter ->
-      let body = Fmt.strf {html|<html>
+        let headers = Cohttp.Header.init_with "Content-Type" "text/html" in
+        next_camel store
+        >>= fun counter ->
+        let body =
+          Fmt.strf
+            {html|<html>
 <body>
 <pre>
                      ,,__
@@ -50,11 +55,12 @@ module Dispatch (Store: Wodan.S) (S: HTTP) = struct
        %Ld camels served!
 </pre>
 </body></html>
-|html} (counter)
-      in
-      S.respond_string ~status:`OK ~body ~headers ()
+|html}
+            counter
+        in
+        S.respond_string ~status:`OK ~body ~headers ()
     | _ ->
-      S.respond_not_found ()
+        S.respond_not_found ()
 
   let serve dispatch =
     let callback (_, cid) request _body =
@@ -63,44 +69,38 @@ module Dispatch (Store: Wodan.S) (S: HTTP) = struct
       Http_log.info (fun f -> f "[%s] serving %s." cid (Uri.to_string uri));
       dispatch uri
     in
-    let conn_closed (_,cid) =
+    let conn_closed (_, cid) =
       let cid = Cohttp.Connection.to_string cid in
-      Http_log.info (fun f -> f "[%s] closing" cid);
+      Http_log.info (fun f -> f "[%s] closing" cid)
     in
     S.make ~conn_closed ~callback ()
-
 end
 
 module HTTP
-    (Time: Mirage_types_lwt.TIME)
-    (Pclock: Mirage_types.PCLOCK)
-    (Http: HTTP)
-    (B: BLOCK)
-= struct
-
-  module B = Wodan.BlockCompat(B)
-
-  module Store = Wodan.Make(B)(Wodan.StandardSuperblockParams)
-  module D = Dispatch(Store)(Http)
+    (Time : Mirage_types_lwt.TIME)
+    (Pclock : Mirage_types.PCLOCK)
+    (Http : HTTP)
+    (B : BLOCK) =
+struct
+  module B = Wodan.BlockCompat (B)
+  module Store = Wodan.Make (B) (Wodan.StandardSuperblockParams)
+  module D = Dispatch (Store) (Http)
 
   let rec periodic_flush store =
     Time.sleep_ns 30_000_000_000L
-    >>= fun () ->
-    Store.flush store
-    >>= fun _gen ->
-    periodic_flush store
+    >>= fun () -> Store.flush store >>= fun _gen -> periodic_flush store
 
   let start _time _clock http block =
     let http_port = Key_gen.http_port () in
     let tcp = `TCP http_port in
     let http =
       Http_log.info (fun f -> f "listening on %d/TCP" http_port);
-      Store.prepare_io Wodan.OpenExistingDevice block Wodan.standard_mount_options
+      Store.prepare_io Wodan.OpenExistingDevice block
+        Wodan.standard_mount_options
       >>= fun (store, _) ->
       Lwt.async (fun () -> periodic_flush store);
       Http_log.info (fun f -> f "store done");
       http tcp @@ D.serve (D.dispatcher store)
     in
-    Lwt.join [ http ]
-
+    Lwt.join [http]
 end

--- a/src/wodan-irmin/bin/dune
+++ b/src/wodan-irmin/bin/dune
@@ -1,17 +1,17 @@
 (executable
-  (name wodan_irmin_cli)
-  (modules wodan_irmin_cli)
-  (public_name wodan-irmin)
-  (package wodan-irmin)
-  (libraries checkseum.c digestif.c wodan-irmin io-page-unix mirage-block-unix mirage-block-ramdisk nocrypto.lwt irmin-unix)
-  )
+ (name wodan_irmin_cli)
+ (modules wodan_irmin_cli)
+ (public_name wodan-irmin)
+ (package wodan-irmin)
+ (libraries checkseum.c digestif.c wodan-irmin io-page-unix mirage-block-unix
+   mirage-block-ramdisk nocrypto.lwt irmin-unix))
 
 (executable
-  (name wodan_git_import)
-  (modules wodan_git_import)
-  (public_name wodan-git-import)
-  (preprocess (pps lwt_ppx))
-  (package wodan-irmin)
-  (libraries checkseum.c digestif.c wodan-irmin io-page-unix mirage-block-unix mirage-block-ramdisk nocrypto.lwt irmin-unix irmin-git)
-  )
-
+ (name wodan_git_import)
+ (modules wodan_git_import)
+ (public_name wodan-git-import)
+ (preprocess
+  (pps lwt_ppx))
+ (package wodan-irmin)
+ (libraries checkseum.c digestif.c wodan-irmin io-page-unix mirage-block-unix
+   mirage-block-ramdisk nocrypto.lwt irmin-unix irmin-git))

--- a/src/wodan-irmin/dune
+++ b/src/wodan-irmin/dune
@@ -1,8 +1,8 @@
 (library
-  (name        wodan_irmin)
-  (public_name wodan-irmin)
-  (flags :standard -g)
-  (ocamlopt_flags :standard -g -O3)
-  (preprocess (pps lwt_ppx))
-  (libraries wodan irmin irmin-chunk irmin-git)
-  )
+ (name wodan_irmin)
+ (public_name wodan-irmin)
+ (flags :standard -g)
+ (ocamlopt_flags :standard -g -O3)
+ (preprocess
+  (pps lwt_ppx))
+ (libraries wodan irmin irmin-chunk irmin-git))

--- a/src/wodan-irmin/wodan_irmin.ml
+++ b/src/wodan-irmin/wodan_irmin.ml
@@ -406,7 +406,8 @@ functor
 
     let key_to_inner_key k =
       Stor.key_of_string
-        (Irmin.Type.to_bin_string H.t (H.digest (Irmin.Type.to_bin_string K.t k)))
+        (Irmin.Type.to_bin_string H.t
+           (H.digest (Irmin.Type.to_bin_string K.t k)))
 
     let val_to_inner_val va =
       Stor.value_of_string (Irmin.Type.to_bin_string V.t va)
@@ -415,10 +416,12 @@ functor
       Stor.value_of_string (Irmin.Type.to_bin_string K.t k)
 
     let key_of_inner_val va =
-      Rresult.R.get_ok (Irmin.Type.of_bin_string K.t (Stor.string_of_value va))
+      Rresult.R.get_ok
+        (Irmin.Type.of_bin_string K.t (Stor.string_of_value va))
 
     let val_of_inner_val va =
-      Rresult.R.get_ok (Irmin.Type.of_bin_string V.t (Stor.string_of_value va))
+      Rresult.R.get_ok
+        (Irmin.Type.of_bin_string V.t (Stor.string_of_value va))
 
     let inner_val_to_inner_key va =
       Stor.key_of_string
@@ -437,17 +440,17 @@ functor
           lock = L.v () }
       in
       ( try%lwt
-              while%lwt true do
-                Stor.lookup root db.magic_key
-                >>= function
-                | None ->
-                    Lwt.fail Exit
-                | Some va ->
-                    let ik = inner_val_to_inner_key va in
-                    KeyHashtbl.add db.keydata ik db.magic_key;
-                    db.magic_key <- Stor.next_key db.magic_key;
-                    Lwt.return_unit
-              done
+          while%lwt true do
+            Stor.lookup root db.magic_key
+            >>= function
+            | None ->
+                Lwt.fail Exit
+            | Some va ->
+                let ik = inner_val_to_inner_key va in
+                KeyHashtbl.add db.keydata ik db.magic_key;
+                db.magic_key <- Stor.next_key db.magic_key;
+                Lwt.return_unit
+          done
         with Exit -> Lwt.return_unit )
       >|= fun () -> db
 

--- a/src/wodan-unix/dune
+++ b/src/wodan-unix/dune
@@ -1,12 +1,12 @@
-
 (executable
-  (name wodanc)
-  (public_name wodanc)
-  (flags :standard -g)
-  (ocamlopt_flags :standard -g -O3)
-  (package wodan-unix)
-  (libraries base64 benchmark csv cmdliner checkseum.c wodan io-page-unix mirage-block-unix mirage-block-ramdisk nocrypto.lwt afl-persistent)
-  (preprocess (pps lwt_ppx))
-  )
+ (name wodanc)
+ (public_name wodanc)
+ (flags :standard -g)
+ (ocamlopt_flags :standard -g -O3)
+ (package wodan-unix)
+ (libraries base64 benchmark csv cmdliner checkseum.c wodan io-page-unix
+   mirage-block-unix mirage-block-ramdisk nocrypto.lwt afl-persistent)
+ (preprocess
+  (pps lwt_ppx)))
 
 (copy_files ../crc32c/crc32c.ml*)

--- a/src/wodan-unix/unikernel.ml
+++ b/src/wodan-unix/unikernel.ml
@@ -67,9 +67,9 @@ module Client (B : Wodan.EXTBLOCK) = struct
             | [k; v] ->
                 compl :=
                   ( try%lwt
-                          Stor.insert root
-                            (Stor.key_of_string (Base64.decode_exn k))
-                            (Stor.value_of_string (Base64.decode_exn v))
+                      Stor.insert root
+                        (Stor.key_of_string (Base64.decode_exn k))
+                        (Stor.value_of_string (Base64.decode_exn v))
                     with Wodan.NeedsFlush ->
                       let%lwt _gen = Stor.flush root in
                       Lwt.return_unit )

--- a/src/wodan/dune
+++ b/src/wodan/dune
@@ -1,10 +1,11 @@
 (library
-  (name        wodan)
-  (public_name wodan)
-  (flags :standard -g)
-  (ocamlopt_flags :standard -g -O3)
-  (preprocess (pps lwt_ppx ppx_cstruct))
-  (libraries rresult stdcompat cstruct sexplib mirage-types mirage-logs lwt io-page lru logs nocrypto bitv mirage-types-lwt diet checkseum)
-  )
+ (name wodan)
+ (public_name wodan)
+ (flags :standard -g)
+ (ocamlopt_flags :standard -g -O3)
+ (preprocess
+  (pps lwt_ppx ppx_cstruct))
+ (libraries rresult stdcompat cstruct sexplib mirage-types mirage-logs lwt
+   io-page lru logs nocrypto bitv mirage-types-lwt diet checkseum))
 
 (copy_files ../crc32c/crc32c.ml*)

--- a/src/wodan/wodan.ml
+++ b/src/wodan/wodan.ml
@@ -705,8 +705,7 @@ struct
           | Result.Error _ ->
               raise ReadError
           | Result.Ok () ->
-              if not (Crc32c.cstruct_valid cstr) then
-                raise (BadCRC logical)
+              if not (Crc32c.cstruct_valid cstr) then raise (BadCRC logical)
               else (cstr, io_data) )
 
   let find_childlinks_offset cstr value_end =
@@ -744,7 +743,7 @@ struct
 
   let rec gen_childlink_offsets start =
     if start >= block_end then []
-    else start :: (gen_childlink_offsets (start + childlink_size))
+    else start :: gen_childlink_offsets (start + childlink_size)
 
   let compute_children entry =
     Logs.debug (fun m -> m "compute_children");
@@ -1308,7 +1307,8 @@ struct
       let median = List.nth binds (n / 2) in
       median
 
-[@@@warning "-32"]
+  [@@@warning "-32"]
+
   let rec check_live_integrity fs alloc_id depth =
     let fail = ref false in
     match lru_peek fs.node_cache.lru alloc_id with
@@ -1439,7 +1439,8 @@ struct
             else check_live_integrity fs child_alloc_id (Int64.succ depth) )
           entry.children_alloc_ids;
         if !fail then failwith "Integrity errors"
-[@@@warning "+32"]
+
+  [@@@warning "+32"]
 
   (* This is equivalent to commenting out the above, while still having it typecheck *)
   let check_live_integrity _ _ _ = ()
@@ -1626,8 +1627,8 @@ struct
               assert (Int64.compare depth 0L > 0);
               Logs.debug (fun m -> m "node splitting %Ld %Ld" depth alloc_id);
               (* Set split_path to prevent spill/split recursion; will split towards the root *)
-              reserve_insert fs parent_key (InsSpaceChild childlink_size)
-                true (Int64.pred depth)
+              reserve_insert fs parent_key (InsSpaceChild childlink_size) true
+                (Int64.pred depth)
               >>= fun () ->
               (* The parent _reserve_insert call may have split the root, causing the parent_key
                  to be updated *)
@@ -1866,8 +1867,7 @@ struct
                 raise BadVersion
               else if get_superblock_incompat_flags sb <> sb_required_incompat
               then raise BadFlags
-              else if not (Crc32c.cstruct_valid sb) then
-                raise (BadCRC 0L)
+              else if not (Crc32c.cstruct_valid sb) then raise (BadCRC 0L)
               else if
                 get_superblock_block_size sb <> Int32.of_int P.block_size
               then (

--- a/tests/wodan-irmin/dune
+++ b/tests/wodan-irmin/dune
@@ -1,16 +1,17 @@
-
 (library
-  (name      test_wodan)
-  (modules   test_wodan)
-  (libraries checkseum.c digestif.c irmin-test irmin-mem io-page-unix nocrypto.lwt mirage-block-ramdisk wodan wodan-irmin))
+ (name test_wodan)
+ (modules test_wodan)
+ (libraries checkseum.c digestif.c irmin-test irmin-mem io-page-unix
+   nocrypto.lwt mirage-block-ramdisk wodan wodan-irmin))
 
 (executable
-  (name      test)
-  (modules   test)
-  (libraries test_wodan))
+ (name test)
+ (modules test)
+ (libraries test_wodan))
 
 (alias
-  (name runtest)
-  (package wodan-irmin)
-  (deps test.exe)
-  (action (run %{dep:test.exe} -q --color=always)))
+ (name runtest)
+ (package wodan-irmin)
+ (deps test.exe)
+ (action
+  (run %{dep:test.exe} -q --color=always)))

--- a/tests/wodan-irmin/test.ml
+++ b/tests/wodan-irmin/test.ml
@@ -14,13 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let misc = [
-  (*"link", [
+let misc = [ (*"link", [
     Test_link.test "wodan" Test_wodan.link;
-  ]*)
-]
+  ]*) ]
 
-let () =
-  Irmin_test.Store.run "irmin" ~misc [
-    `Quick , Test_wodan.suite;
-  ]
+let () = Irmin_test.Store.run "irmin" ~misc [(`Quick, Test_wodan.suite)]

--- a/tests/wodan-irmin/test_wodan.ml
+++ b/tests/wodan-irmin/test_wodan.ml
@@ -18,24 +18,30 @@ open Lwt.Infix
 
 module BlockCon = struct
   include Ramdisk
+
   let connect name = Ramdisk.connect ~name
+
   let discard _ _ _ = Lwt.return (Ok ())
 end
 
-module DB_ram = Wodan_irmin.DB_BUILDER(BlockCon)(Wodan.StandardSuperblockParams)
+module DB_ram =
+  Wodan_irmin.DB_BUILDER (BlockCon) (Wodan.StandardSuperblockParams)
 
 (* let store = Irmin_test.store (module Wodan_irmin.Make(DB_ram)) (module Irmin.Metadata.None) *)
-let store = (module
-  Wodan_irmin.KV_chunked(DB_ram)(Irmin.Contents.String)
-: Irmin_test.S)
+let store =
+  (module Wodan_irmin.KV_chunked (DB_ram) (Irmin.Contents.String)
+  : Irmin_test.S )
 
 let config = Wodan_irmin.config ~path:"disk.img" ~create:true ()
 
 let clean () =
-  let (module S: Irmin_test.S) = store in
-  S.Repo.v config >>= fun repo ->
+  let (module S : Irmin_test.S) = store in
+  S.Repo.v config
+  >>= fun repo ->
   S.Repo.branches repo >>= Lwt_list.iter_p (S.Branch.remove repo)
 
 let init () = Nocrypto_entropy_lwt.initialize ()
+
 let stats = None
-let suite = { Irmin_test.name = "WODAN"; init; clean; config; store; stats }
+
+let suite = {Irmin_test.name = "WODAN"; init; clean; config; store; stats}

--- a/wodan-irmin.opam
+++ b/wodan-irmin.opam
@@ -14,12 +14,14 @@ build: [
 
 build-test: [
   [ "dune" "runtest" "-p" name ]
+  [ "dune" "build" "@fmt" "-p" name ]
 ]
 
 depends: [
   "ocamlfind" {build}
-  "dune"  {build}
+  "dune"  {build & >= "1.7"}
 
+  "ocamlformat" {test}
   "alcotest" {test}
   "bos" {test}
   "cstruct" {test}

--- a/wodan-unix.opam
+++ b/wodan-unix.opam
@@ -14,12 +14,14 @@ build: [
 
 build-test: [
   [ "dune" "runtest" "-p" name ]
+  [ "dune" "build" "@fmt" "-p" name ]
 ]
 
 depends: [
   "ocamlfind" {build}
-  "dune"  {build & >= "1.3"}
+  "dune"  {build & >= "1.7"}
 
+  "ocamlformat" {test}
   "alcotest" {test}
   "bos" {test}
   "cstruct" {test}

--- a/wodan.opam
+++ b/wodan.opam
@@ -14,12 +14,14 @@ build: [
 
 build-test: [
   [ "dune" "runtest" "-p" name ]
+  [ "dune" "build" "@fmt" "-p" name ]
 ]
 
 depends: [
   "ocamlfind" {build}
-  "dune" {build & >= "1.3"}
+  "dune"  {build & >= "1.7"}
 
+  "ocamlformat" {test}
   "alcotest" {test}
   "bos" {test}
   "ezjsonm" {test}


### PR DESCRIPTION
Use dune for formatting, and add it to tests so that the CI fails if the code does not comply (including examples and tests).
We should wait until vendors are removed, because they don't use the same formatting hence the CI will fail.