### PR TITLE
Separate Bitv64 module

### DIFF
--- a/src/wodan/bitv64.ml
+++ b/src/wodan/bitv64.ml
@@ -1,0 +1,16 @@
+type t = Bitv.t
+
+let create size bit =
+  if Int64.compare size (Int64.of_int max_int) > 0 then
+    raise (Invalid_argument "Bitv64.create");
+  Bitv.create (Int64.to_int size) bit
+
+let set vec off bit = Bitv.set vec (Int64.to_int off) bit
+
+let get vec off = Bitv.get vec (Int64.to_int off)
+
+let length vec = Int64.of_int (Bitv.length vec)
+
+let iter = Bitv.iter
+
+let iteri f t = Bitv.iteri (fun i b -> f (Int64.of_int i) b) t

--- a/src/wodan/bitv64.mli
+++ b/src/wodan/bitv64.mli
@@ -1,0 +1,26 @@
+(** Bitv64 is a wrapper around Bitv, for easier use with int64 indexes and
+    sizes. *)
+
+(** The type for [int64] indexed [Bitv]s *)
+type t
+
+val create : int64 -> bool -> t
+(** [create n b] creates a new bit vector of length [n],
+    initialized with [b].
+    [n] must be smaller than [max_int], otherwise raises Invalid_argument. *)
+
+val set : t -> int64 -> bool -> unit
+(** [Bitv.set v n b] sets the [n]th bit of [v] to the value [b]. *)
+
+val get : t -> int64 -> bool
+(** [Bitv.get v n] returns the [n]th bit of [v]. *)
+
+val length : t -> int64
+(** [length] returns the length of the given vector. *)
+
+val iter : (bool -> unit) -> t -> unit
+(** [iter f v] applies [f] to every element in [v]. *)
+
+val iteri : (int64 -> bool -> unit) -> t -> unit
+(** [iteri] is like [iter], but applies f to the index of the element,
+    as first argument, and to the element itself, as second argument. *)


### PR DESCRIPTION
This simple PR moves Bitv related functions to a module with an abstract type, this way 
```
(* Safe as long as bitv_create64 is used *)
```
is always enforced.