### PR TITLE
Extract a statistics module

### DIFF
--- a/src/wodan/wodan.ml
+++ b/src/wodan/wodan.ml
@@ -179,8 +179,6 @@ module Statistics : sig
 
   val pp : Format.formatter -> t -> unit
 
-  val inserts : t -> int
-
   val add_insert : t -> unit
 
   val add_lookup : t -> unit
@@ -201,8 +199,6 @@ end = struct
   let pp fmt {inserts; lookups; range_searches; iters} =
     Format.fprintf fmt "Ops: %d inserts %d lookups %d range searches %d iters"
       inserts lookups range_searches iters
-
-  let inserts t = t.inserts
 
   let add_insert t = t.inserts <- succ t.inserts
 
@@ -1416,11 +1412,9 @@ struct
           entry.logdata.logdata_contents;
         if !vend != entry.logdata.value_end then (
           Logs.err (fun m ->
-              m
-                "Inconsistent value_end depth:%Ld expected:%d actual:%d \
-                 inserts:%d"
-                depth !vend entry.logdata.value_end
-                (Statistics.inserts fs.node_cache.statistics) );
+              m "Inconsistent value_end depth:%Ld expected:%d actual:%d %a"
+                depth !vend entry.logdata.value_end Statistics.pp
+                fs.node_cache.statistics );
           fail := true );
         ( match entry.flush_children with
         | Some di -> (

--- a/src/wodan/wodan.ml
+++ b/src/wodan/wodan.ml
@@ -198,8 +198,9 @@ end = struct
 
   let default = {inserts = 0; lookups = 0; range_searches = 0; iters = 0}
 
-  let pp fmt {inserts; lookups; _} =
-    Format.fprintf fmt "Ops: %d inserts %d lookups" inserts lookups
+  let pp fmt {inserts; lookups; range_searches; iters} =
+    Format.fprintf fmt "Ops: %d inserts %d lookups %d range searches %d iters"
+      inserts lookups range_searches iters
 
   let inserts t = t.inserts
 

--- a/src/wodan/wodan.ml
+++ b/src/wodan/wodan.ml
@@ -175,7 +175,7 @@ let _sb_io block_io = Cstruct.sub block_io 0 sizeof_superblock
 module Statistics : sig
   type t
 
-  val default : t
+  val create : unit -> t
 
   val pp : Format.formatter -> t -> unit
 
@@ -194,7 +194,7 @@ end = struct
     mutable iters : int
   }
 
-  let default = {inserts = 0; lookups = 0; range_searches = 0; iters = 0}
+  let create () = {inserts = 0; lookups = 0; range_searches = 0; iters = 0}
 
   let pp fmt {inserts; lookups; range_searches; iters} =
     Format.fprintf fmt "Ops: %d inserts %d lookups %d range searches %d iters"
@@ -2083,7 +2083,7 @@ struct
             fsid;
             next_logical_alloc = lroot;
             (* in use, but that's okay *)
-            statistics = Statistics.default }
+            statistics = Statistics.create () }
         in
         let open_fs = {filesystem = fs; node_cache} in
         (* TODO add more integrity checking *)
@@ -2115,7 +2115,7 @@ struct
             dirty_count = 0L;
             fsid;
             next_logical_alloc = first_block_written;
-            statistics = Statistics.default }
+            statistics = Statistics.create () }
         in
         let open_fs = {filesystem = fs; node_cache} in
         _format open_fs logical_size first_block_written fsid

--- a/src/wodan/wodan_statistics.ml
+++ b/src/wodan/wodan_statistics.ml
@@ -1,0 +1,20 @@
+type t = {
+  mutable inserts : int;
+  mutable lookups : int;
+  mutable range_searches : int;
+  mutable iters : int
+}
+
+let create () = {inserts = 0; lookups = 0; range_searches = 0; iters = 0}
+
+let pp fmt {inserts; lookups; range_searches; iters} =
+  Format.fprintf fmt "Ops: %d inserts %d lookups %d range searches %d iters"
+    inserts lookups range_searches iters
+
+let add_insert t = t.inserts <- succ t.inserts
+
+let add_lookup t = t.lookups <- succ t.lookups
+
+let add_range_search t = t.range_searches <- succ t.range_searches
+
+let add_iter t = t.iters <- succ t.iters

--- a/src/wodan/wodan_statistics.mli
+++ b/src/wodan/wodan_statistics.mli
@@ -1,0 +1,13 @@
+type t
+
+val create : unit -> t
+
+val pp : Format.formatter -> t -> unit
+
+val add_insert : t -> unit
+
+val add_lookup : t -> unit
+
+val add_range_search : t -> unit
+
+val add_iter : t -> unit


### PR DESCRIPTION
Hi,

This is similar to #58 and the same questions regarding pulling out to an external file apply.
In `master`, a single statistics record is used - this changes this so that a new one is allocated at every device open. That seems easier to reason about, but I'm not sure where these stats are used.

Let me know what you think @pascutto @g2p. Thanks!