### PR TITLE
Minor (meta) fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-/_build/
-/_opam/
+_build
+_opam
 /afl/output/
-/wodan*.install
+*.install
 .merlin
 *.img
+wodanc

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-_build
-_opam
+/_build/
+/_opam/
 /afl/output/
-*.install
+/wodan*.install
 .merlin
 *.img
-wodanc
+/wodanc

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 build:
 	dune build
-	ln -Tsf _build/default/src/wodan-unix/wodanc.exe wodanc
+	ln -sf _build/default/src/wodan-unix/wodanc.exe wodanc
 
 deps:
 	git submodule update --init --recursive
@@ -21,7 +21,7 @@ fuzz:
 		_build/default/src/wodan-unix/wodanc.exe fuzz @@
 
 test:
-	dune runtest
+	dune runtest tests
 
 install:
 	dune install
@@ -30,6 +30,6 @@ uninstall:
 	dune uninstall
 
 clean:
-	rm -rf _build _opam
+	rm -rf _build wodanc
 
 .PHONY: build deps ocamlformat fuzz test install uninstall clean


### PR DESCRIPTION
- Add  `wodanc` to `.gitignore` and `make clean`
- Remove `_opam` from `make clean` (wipes local switches)
- Remove `-T` option from `ln` (fails on macOS and should not be useful here anyway)
- Have `make test` to run only local tests (otherwise also runs irmin vendored tests)
