### PR TITLE
Specify we use lru v0.2.0

### DIFF
--- a/wodan.opam
+++ b/wodan.opam
@@ -37,7 +37,7 @@ depends: [
   "diet" {>= "0.2"}
   "io-page"
   "logs"
-  "lru"
+  "lru" {= "0.2.0"}
   "lwt" {>= "3.1.0"}
   "lwt_ppx"
   "mirage-logs"


### PR DESCRIPTION
The newer version v0.3.0 breaks compatibility, and can't be used because
it conflicts with the current newest decompress, used by ocaml-git.