### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/wodan-irmin.opam
+++ b/wodan-irmin.opam
@@ -19,7 +19,7 @@ build-test: [
 
 depends: [
   "ocamlfind" {build}
-  "dune"  {build & >= "1.7"}
+  "dune"  {>= "1.7"}
 
   "ocamlformat" {test}
   "alcotest" {test}

--- a/wodan-unix.opam
+++ b/wodan-unix.opam
@@ -19,7 +19,7 @@ build-test: [
 
 depends: [
   "ocamlfind" {build}
-  "dune"  {build & >= "1.7"}
+  "dune"  {>= "1.7"}
 
   "ocamlformat" {test}
   "alcotest" {test}

--- a/wodan.opam
+++ b/wodan.opam
@@ -19,7 +19,7 @@ build-test: [
 
 depends: [
   "ocamlfind" {build}
-  "dune"  {build & >= "1.7"}
+  "dune"  {>= "1.7"}
 
   "ocamlformat" {test & = "0.9"}
   "alcotest" {test}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.