### PR TITLE
preload_child/load_child_node_at: don't waste an alloc_id

### DIFF
--- a/src/wodan/wodan.ml
+++ b/src/wodan/wodan.ml
@@ -813,7 +813,7 @@ struct
         prev_logical = Some logical }
     in
     lru_xset cache.lru alloc_id entry;
-    Lwt.return entry
+    Lwt.return (alloc_id, entry)
 
   let has_children entry = not (KeyedMap.is_empty entry.children)
 
@@ -1216,12 +1216,10 @@ struct
                 let parent_gen = entry.generation in
                 scan_all_nodes open_fs logical false rdepth parent_gen true )
         >>= fun () ->
-        let%lwt child_entry =
+        let%lwt (alloc_id, child_entry) =
           load_child_node_at open_fs logical child_key entry_key rdepth
         in
-        let alloc_id = next_alloc_id cache in
         KeyedMap.xadd entry.children_alloc_ids child_key alloc_id;
-        lru_xset cache.lru alloc_id child_entry;
         Lwt.return (alloc_id, child_entry)
     | Some alloc_id -> (
       match lru_get cache.lru alloc_id with


### PR DESCRIPTION
Fix creating a transient alloc_id to discard it immediately after.

preload_child and load_child_node_at both called next_alloc_id, the former called the later, remove the outer next_alloc_id call which was unnecessary.

The bug was introduced in cab21d1f3c0061e24be62a508e0c322647de1dc2.