### PR TITLE
Assorted dependencies fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,5 @@ matrix:
   - env: OCAML_VERSION=4.08 PACKAGE=wodan
   - env: OCAML_VERSION=4.08 PACKAGE=wodan-unix
   - env: OCAML_VERSION=4.08 PACKAGE=wodan-irmin
-  - env: OCAML_VERSION=4.07 PACKAGE=wodan
-  - env: OCAML_VERSION=4.07 PACKAGE=wodan-unix
-  - env: OCAML_VERSION=4.07 PACKAGE=wodan-irmin
 os:
   - linux

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ uninstall:
 	dune uninstall
 
 clean:
-	rm -rf _build wodanc
+	dune clean
+	rm -f wodanc
 
 .PHONY: build deps ocamlformat fuzz doc test install uninstall clean

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ filesystem library for Mirage OS.
 
 It provides a key-value store as well as an Irmin backend.
 
-[![Build Status](https://travis-ci.org/mirage/wodan.svg?branch=master)](https://travis-ci.org/mirage/wodan)
+[![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Fmirage%2Fwodan%2Fmaster&logo=ocaml)](https://ci.ocamllabs.io/github/mirage/wodan)
+[![Travis Build Status](https://travis-ci.org/mirage/wodan.svg?branch=master)](https://travis-ci.org/mirage/wodan)
 
 ## Status
 
@@ -122,15 +123,9 @@ make fuzz
 
 ## Contributing
 
-The code is formatted using `ocamlformat` and complies to the options described
-in `.ocamlformat` used with the development version of `ocamlformat` (until the
-next release).
-
-Please pin the package to their git repository :
-<https://github.com/ocaml-ppx/ocamlformat>
-
-And make sure the code is well formatted before any commit by executing
-`make ocamlformat`.
+You can rely on the CI for some checks, you can also run tests with
+`make test` and ensure the code is well formatted by running
+`make ocamlformat` before any commit.
 
 [opam]: https://opam.ocaml.org/
 [dune]: https://github.com/ocaml/dune#installation

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This explains some of the design choices behind Wodan.
 ## Building, installing and running
 
 Wodan requires [Opam 2][opam], [Dune][dune], [Mirage 3][mirage],
-and [OCaml 4.07 through 4.11][ocaml].
+and [OCaml 4.08 through 4.11][ocaml].
 
 An opam switch with flambda is recommended for performance reasons.
 

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,3 @@
 (lang dune 2.3)
 (name wodan)
 (implicit_transitive_deps false)
-(strict_package_deps true)
-(package (name wodan))
-(package (name wodan-unix) (depends wodan))
-(package (name wodan-irmin) (depends wodan))

--- a/src/wodan/dune
+++ b/src/wodan/dune
@@ -5,5 +5,5 @@
  (ocamlopt_flags :standard -g -O3)
  (preprocess
   (pps lwt_ppx ppx_cstruct))
- (libraries rresult stdcompat cstruct mirage-block lwt io-page lru logs
-   nocrypto bitv diet checkseum optint result))
+ (libraries cstruct mirage-block lwt io-page lru logs nocrypto bitv diet
+   checkseum optint))

--- a/src/wodan/keyedmap.ml
+++ b/src/wodan/keyedmap.ml
@@ -1,5 +1,3 @@
-open Stdcompat
-
 module type OrderedType = sig
   type t
 

--- a/src/wodan/location.ml
+++ b/src/wodan/location.ml
@@ -6,8 +6,7 @@ exception TooLarge
 exception NotUnsigned
 
 let of_int64 v =
-  if Int64.compare v (Int64.of_int Stdcompat.Stdlib.max_int) > 0 then
-    raise TooLarge
+  if Int64.compare v (Int64.of_int Stdlib.max_int) > 0 then raise TooLarge
   else if Int64.compare v 0L < 0 then raise NotUnsigned
   else v
 

--- a/src/wodan/wodan.ml
+++ b/src/wodan/wodan.ml
@@ -1065,7 +1065,7 @@ struct
           (mul n (of_int P.block_size))
           (of_int open_fs.filesystem.other_sector_size))
     >|= function
-    | res -> Rresult.R.get_ok res
+    | res -> Result.get_ok res
 
   let fstrim root =
     let open_fs = root.open_fs in

--- a/tests/wodan-irmin/dune
+++ b/tests/wodan-irmin/dune
@@ -1,4 +1,5 @@
 (test
  (name test)
+ (package wodan-irmin)
  (libraries alcotest irmin-test io-page-unix nocrypto.lwt
    mirage-block-ramdisk wodan wodan-irmin lwt irmin))

--- a/tests/wodan-irmin/dune
+++ b/tests/wodan-irmin/dune
@@ -1,17 +1,4 @@
-(library
- (name test_wodan)
- (modules test_wodan)
- (libraries checkseum.c digestif.c irmin-test irmin-mem io-page-unix
-   nocrypto.lwt mirage-block-ramdisk wodan wodan-irmin lwt irmin))
-
-(executable
+(test
  (name test)
- (modules test)
- (libraries test_wodan irmin-test alcotest))
-
-(rule
- (alias runtest)
- (package wodan-irmin)
- (deps test.exe)
- (action
-  (run %{dep:test.exe} -q --color=always)))
+ (libraries alcotest irmin-test io-page-unix nocrypto.lwt
+   mirage-block-ramdisk wodan wodan-irmin lwt irmin))

--- a/wodan-irmin.opam
+++ b/wodan-irmin.opam
@@ -8,32 +8,26 @@ name: "wodan-irmin"
 synopsis: "Wodan as an Irmin store"
 
 build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-  ["dune" "build" "@fmt" "-p" name ] {with-test}
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
 ]
 
 depends: [
-  "ocamlfind" {build}
-  "dune"  {>= "1.7"}
-
-  "ocamlformat" {with-test}
+  "ocaml"
+  "dune"  {>= "2.3.0"}
   "alcotest" {with-test}
-  "bos" {with-test}
-  "cstruct" {with-test}
-  "diet" {with-test}
-  "ezjsonm" {with-test}
-  "io-page" {with-test}
-  "irmin-mem" {with-test}
   "irmin-test" {with-test}
-  "logs" {with-test}
-  "lwt" {with-test}
   "mirage-block-unix" {with-test}
-  "ounit" {with-test}
-  "ocaml-migrate-parsetree" {with-test}
-  "ppx_sexp_conv" {with-test}
-  "yaml" {with-test}
-
   "checkseum" {>= "0.0.2"}
   "digestif"
   "io-page-unix"
@@ -41,6 +35,7 @@ depends: [
   "irmin-chunk"
   "irmin-git"
   "irmin-unix"
+  "lwt"
   "lwt_ppx"
   "mirage-block-ramdisk"
   "mirage-block-unix"

--- a/wodan-unix.opam
+++ b/wodan-unix.opam
@@ -8,29 +8,23 @@ name: "wodan-unix"
 synopsis: "Wodan clients with Unix integration"
 
 build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-  ["dune" "build" "@fmt" "-p" name ] {with-test}
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
 ]
 
 depends: [
-  "ocamlfind" {build}
-  "dune"  {>= "1.7"}
-  "ocamlformat" {with-test}
-  "alcotest" {with-test}
-  "bos" {with-test}
-  "cstruct" {with-test}
-  "diet" {with-test}
-  "ezjsonm" {with-test}
-  "io-page" {with-test}
-  "logs" {with-test}
-  "lwt" {with-test}
-  "mirage-block-unix" {with-test}
-  "ounit" {with-test}
-  "ocaml-migrate-parsetree" {with-test}
-  "ppx_sexp_conv" {with-test}
-  "yaml" {with-test}
-
+  "ocaml"
+  "dune"  {>= "2.3.0"}
   "afl-persistent"
   "base64" {>= "3.0.0"}
   "benchmark"

--- a/wodan.opam
+++ b/wodan.opam
@@ -23,7 +23,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune"  {>= "1.7"}
   "bitv"
   "checkseum" {>= "0.0.2"}
@@ -37,8 +37,6 @@ depends: [
   "mirage-block" {>= "2.0.0"}
   "nocrypto"
   "ppx_cstruct"
-  "rresult"
-  "stdcompat"
 ]
 
 pin-depends: [

--- a/wodan.opam
+++ b/wodan.opam
@@ -8,25 +8,23 @@ name: "wodan"
 synopsis: "A flash-friendly, safe and flexible filesystem library"
 
 build: [
-  ["dune" "build" "-p" name ]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-  ["dune" "build" "@fmt" "-p" name ] {with-test}
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
 ]
 
 depends: [
-  "ocamlfind" {build}
+  "ocaml" {>= "4.07.0"}
   "dune"  {>= "1.7"}
-
-  "ocamlformat" {with-test & = "0.15.0"}
-  "alcotest" {with-test}
-  "bos" {with-test}
-  "ezjsonm" {with-test}
-  "mirage-block-unix" {with-test}
-  "ounit" {with-test}
-  "ocaml-migrate-parsetree" {with-test}
-  "ppx_sexp_conv" {with-test}
-  "yaml" {with-test}
-
   "bitv"
   "checkseum" {>= "0.0.2"}
   "cstruct"
@@ -41,7 +39,6 @@ depends: [
   "ppx_cstruct"
   "rresult"
   "stdcompat"
-  "ocaml" {>= "4.07.0"}
 ]
 
 pin-depends: [


### PR DESCRIPTION
- Removes unused dependencies (mostly tests)
- Removes ocamlformat from the build instructions and the readme, as we since came up with another standard workflow.
- Require OCaml 4.08. This enables the handy "new" stdlib, and removes some dependencies such as `rresult` and `stdcompat`. This is coherent with our support policy for other mirage projects.