### PR TITLE
Tombstones work

### DIFF
--- a/examples/solo5-irmin/dispatch.ml
+++ b/examples/solo5-irmin/dispatch.ml
@@ -16,7 +16,8 @@ module BlockCon = struct
   let discard _ _ _ = Lwt.return (Ok ())
 end
 
-module DB = Wodan_irmin.DB_BUILDER (BlockCon) (Wodan.StandardSuperblockParams)
+module DB =
+  Wodan_irmin.DB_BUILDER (BlockCon) (Wodan_irmin.StandardSuperblockParams)
 module Wodan_Git_KV = Wodan_irmin.KV_git (DB)
 
 module Dispatch (S : HTTP) = struct

--- a/src/wodan-irmin/bin/wodan_git_import.ml
+++ b/src/wodan-irmin/bin/wodan_git_import.ml
@@ -22,7 +22,7 @@ module Wodan_DB =
 
       let connect name = Block.connect name
     end)
-    (Wodan.StandardSuperblockParams)
+    (Wodan_irmin.StandardSuperblockParams)
 
 module Wodan_nongit_S =
   Wodan_irmin.KV_chunked (Wodan_DB) (Irmin.Hash.SHA1) (Irmin.Contents.String)

--- a/src/wodan-irmin/bin/wodan_irmin_cli.ml
+++ b/src/wodan-irmin/bin/wodan_irmin_cli.ml
@@ -26,7 +26,7 @@ module RamBlockCon = struct
 end
 
 module DB_ram =
-  Wodan_irmin.DB_BUILDER (RamBlockCon) (Wodan.StandardSuperblockParams)
+  Wodan_irmin.DB_BUILDER (RamBlockCon) (Wodan_irmin.StandardSuperblockParams)
 
 module FileBlockCon = struct
   include Block
@@ -35,7 +35,7 @@ module FileBlockCon = struct
 end
 
 module DB_fs =
-  Wodan_irmin.DB_BUILDER (FileBlockCon) (Wodan.StandardSuperblockParams)
+  Wodan_irmin.DB_BUILDER (FileBlockCon) (Wodan_irmin.StandardSuperblockParams)
 
 let _ =
   Resolver.Store.add "wodan-mem"

--- a/src/wodan-irmin/wodan_irmin.ml
+++ b/src/wodan-irmin/wodan_irmin.ml
@@ -21,8 +21,7 @@ let src = Logs.Src.create "irmin.wodan"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let standard_mount_options =
-  {Wodan.standard_mount_options with has_tombstone = true}
+let standard_mount_options = Wodan.standard_mount_options
 
 module Conf = struct
   let path =
@@ -476,7 +475,7 @@ functor
       t
 
     let set_and_list db ik iv ikv =
-      assert (not (Stor.is_tombstone (db_root db) iv));
+      assert (not (Stor.is_tombstone iv));
       ( if not (KeyHashtbl.mem db.keydata ik) then (
         KeyHashtbl.add db.keydata ik db.magic_key;
         may_autoflush db (fun () -> Stor.insert (db_root db) db.magic_key ikv)

--- a/src/wodan-irmin/wodan_irmin.ml
+++ b/src/wodan-irmin/wodan_irmin.ml
@@ -23,6 +23,12 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 let standard_mount_options = Wodan.standard_mount_options
 
+module StandardSuperblockParams : Wodan.SUPERBLOCK_PARAMS = struct
+  include Wodan.StandardSuperblockParams
+
+  let optional_flags = Wodan.OptionalSuperblockFlags.tombstones_enabled
+end
+
 module Conf = struct
   let path =
     Irmin.Private.Conf.key ~doc:"Path to filesystem image" "path"
@@ -237,6 +243,16 @@ functor
         make ~path ~create ~mount_options ~autoflush
     end)
 
+    (* Must support tombstones
+
+       This is important for AW_BUILDER-derived stores.
+       Since we have a Cache module allowing filesystems to be shared
+       between multiple Irmin instances, we must enable tombstones in
+       all cases, and extend values by one byte everywhere. *)
+    let () =
+      assert (
+        P.optional_flags = Wodan.OptionalSuperblockFlags.tombstones_enabled )
+
     let v config =
       let module C = Irmin.Private.Conf in
       let path = C.get config Conf.path in
@@ -273,16 +289,25 @@ functor
 
     let () = assert (K.hash_size = DB.Stor.P.key_size)
 
+    let val_to_inner va =
+      let raw_v = Irmin.Type.to_bin_string V.t va in
+      let k = K.hash (fun f -> f raw_v) in
+      let raw_k = Irmin.Type.to_bin_string K.t k in
+      (k, DB.Stor.key_of_string raw_k, DB.Stor.value_of_string ("C" ^ raw_v))
+
+    let val_of_inner_val va =
+      let va1 = DB.Stor.string_of_value va in
+      assert (va1.[0] = 'C');
+      let va2 = String.sub va1 1 (String.length va1 - 1) in
+      Result.get_ok (Irmin.Type.of_bin_string V.t va2)
+
     let find db k =
       Log.debug (fun l -> l "CA.find %a" (Irmin.Type.pp K.t) k);
       DB.Stor.lookup (DB.db_root db)
         (DB.Stor.key_of_string (Irmin.Type.to_bin_string K.t k))
       >>= function
       | None -> Lwt.return_none
-      | Some v ->
-          Lwt.return_some
-            (Result.get_ok
-               (Irmin.Type.of_bin_string V.t (DB.Stor.string_of_value v)))
+      | Some v -> Lwt.return_some (val_of_inner_val v)
 
     let mem db k =
       Log.debug (fun l -> l "CA.mem %a" (Irmin.Type.pp K.t) k);
@@ -290,19 +315,11 @@ functor
         (DB.Stor.key_of_string (Irmin.Type.to_bin_string K.t k))
 
     let add db va =
-      let raw_v = Irmin.Type.to_bin_string V.t va in
-      let k = K.hash (fun f -> f raw_v) in
+      let k, ik, iv = val_to_inner va in
       Log.debug (fun m ->
           m "CA.add -> %a (%d)" (Irmin.Type.pp K.t) k K.hash_size);
-      (*Log.debug (fun m -> m "AO.add -> %a (%d) -> %a" (Irmin.Type.pp K.t) k K.hash_size (Irmin.Type.pp V.t) va);*)
-      (*Log.debug (fun m -> m "AO.add -> %a (%d) -> %s" (Irmin.Type.pp K.t) k K.hash_size raw_v);*)
-      let raw_k = Irmin.Type.to_bin_string K.t k in
       let root = DB.db_root db in
-      DB.may_autoflush db (fun () ->
-          DB.Stor.insert root
-            (DB.Stor.key_of_string raw_k)
-            (DB.Stor.value_of_string raw_v))
-      >>= function
+      DB.may_autoflush db (fun () -> DB.Stor.insert root ik iv) >>= function
       | () -> Lwt.return k
 
     let unsafe_add db k va =
@@ -338,16 +355,22 @@ functor
 
     type value = V.t
 
+    let val_to_inner_val va =
+      DB.Stor.value_of_string ("A" ^ Irmin.Type.to_bin_string V.t va)
+
+    let val_of_inner_val va =
+      let va1 = DB.Stor.string_of_value va in
+      assert (va1.[0] = 'A');
+      let va2 = String.sub va1 1 (String.length va1 - 1) in
+      Result.get_ok (Irmin.Type.of_bin_string V.t va2)
+
     let find db k =
       Log.debug (fun l -> l "AO.find %a" (Irmin.Type.pp K.t) k);
       DB.Stor.lookup (DB.db_root db)
         (DB.Stor.key_of_string (Irmin.Type.to_bin_string K.t k))
       >>= function
       | None -> Lwt.return_none
-      | Some v ->
-          Lwt.return_some
-            (Result.get_ok
-               (Irmin.Type.of_bin_string V.t (DB.Stor.string_of_value v)))
+      | Some v -> Lwt.return_some (val_of_inner_val v)
 
     let mem db k =
       Log.debug (fun l -> l "AO.mem %a" (Irmin.Type.pp K.t) k);
@@ -355,13 +378,12 @@ functor
         (DB.Stor.key_of_string (Irmin.Type.to_bin_string K.t k))
 
     let add db k va =
-      let raw_v = Irmin.Type.to_bin_string V.t va in
       let raw_k = Irmin.Type.to_bin_string K.t k in
       let root = DB.db_root db in
       DB.may_autoflush db (fun () ->
           DB.Stor.insert root
             (DB.Stor.key_of_string raw_k)
-            (DB.Stor.value_of_string raw_v))
+            (val_to_inner_val va))
 
     let v = DB.v
 
@@ -405,13 +427,18 @@ functor
 
     type value = V.t
 
+    (* The outside layer is Irmin, the inner layer is Wodan, here are some conversions *)
     let key_to_inner_key k =
       Stor.key_of_string
         (Irmin.Type.to_bin_string H.t
            (H.hash (fun f -> f (Irmin.Type.to_bin_string K.t k))))
 
+    (* Prefix values so that we can use both tombstones and empty values
+
+       Irmin.Type.to_bin_string can produce empty values, unlike some
+       other Irmin serializers that encode length up-front *)
     let val_to_inner_val va =
-      Stor.value_of_string (Irmin.Type.to_bin_string V.t va)
+      Stor.value_of_string ("V" ^ Irmin.Type.to_bin_string V.t va)
 
     let key_to_inner_val k =
       Stor.value_of_string (Irmin.Type.to_bin_string K.t k)
@@ -420,8 +447,13 @@ functor
       Result.get_ok (Irmin.Type.of_bin_string K.t (Stor.string_of_value va))
 
     let val_of_inner_val va =
-      Result.get_ok (Irmin.Type.of_bin_string V.t (Stor.string_of_value va))
+      let va1 = Stor.string_of_value va in
+      assert (va1.[0] = 'V');
+      let va2 = String.sub va1 1 (String.length va1 - 1) in
+      Result.get_ok (Irmin.Type.of_bin_string V.t va2)
 
+    (* Convert a Wodan value to a Wodan key
+       Used to traverse the linked list that lists all keys stored through the AW interface *)
     let inner_val_to_inner_key va =
       Stor.key_of_string
         (Irmin.Type.to_bin_string H.t
@@ -534,13 +566,14 @@ functor
       (if updated then W.notify db.watches k set else Lwt.return_unit)
       >>= fun () -> Lwt.return updated
 
+    let tombstone = Stor.value_of_string ""
+
     let remove db k =
       Log.debug (fun l -> l "AW.remove %a" (Irmin.Type.pp K.t) k);
       let ik = key_to_inner_key k in
-      let va = Stor.value_of_string "" in
       let root = db_root db in
       L.with_lock db.lock k (fun () ->
-          may_autoflush db (fun () -> Stor.insert root ik va))
+          may_autoflush db (fun () -> Stor.insert root ik tombstone))
       >>= fun () -> W.notify db.watches k None
 
     let list db =

--- a/src/wodan-irmin/wodan_irmin.mli
+++ b/src/wodan-irmin/wodan_irmin.mli
@@ -19,6 +19,11 @@ module Log : Logs.LOG
 
 val standard_mount_options : Wodan.mount_options
 
+module StandardSuperblockParams : Wodan.SUPERBLOCK_PARAMS
+(** Defaults for {!SUPERBLOCK_PARAMS}
+
+    Unlike {!Wodan.SUPERBLOCK_PARAMS}, this has tombstones enabled *)
+
 module Conf : sig
   val path : string Irmin.Private.Conf.key
 
@@ -78,7 +83,8 @@ module CA_BUILDER : functor (_ : DB) -> Irmin.CONTENT_ADDRESSABLE_STORE_MAKER
 (** Builds an {!Irmin.ATOMIC_WRITE_STORE}, storing key to value mappings with
     extra features
 
-    Extra features currently incude: atomicity and watches, listing all keys *)
+    Extra features currently incude: atomicity and watches, listing all keys,
+    deleting keys. *)
 module AW_BUILDER : functor (_ : DB) (_ : Irmin.Hash.S) ->
   Irmin.ATOMIC_WRITE_STORE_MAKER
 

--- a/src/wodan/wodan.ml
+++ b/src/wodan/wodan.ml
@@ -790,9 +790,7 @@ struct
   }
 
   let is_tombstone value =
-    OptionalSuperblockFlags.intersect P.optional_flags
-      OptionalSuperblockFlags.tombstones_enabled
-    <> OptionalSuperblockFlags.empty
+    OptionalSuperblockFlags.(intersect P.optional_flags tombstones_enabled <> empty)
     && String.length value = 0
 
   let load_data_at filesystem logical =

--- a/src/wodan/wodan.ml
+++ b/src/wodan/wodan.ml
@@ -96,9 +96,16 @@ let sb_incompat_fsid = 2l
 
 let sb_incompat_value_count = 4l
 
+let sb_incompat_tombstones = 8l
+
 let sb_required_incompat =
   Int32.logor sb_incompat_rdepth
     (Int32.logor sb_incompat_fsid sb_incompat_value_count)
+
+let sb_optional_incompat = sb_incompat_tombstones
+
+let sb_accepted_incompat =
+  Int32.logor sb_required_incompat sb_optional_incompat
 
 [@@@warning "-32"]
 
@@ -107,6 +114,7 @@ type%cstruct superblock = {
   magic : uint8_t; [@len 16]
   (* major version, all later fields may change if this does *)
   version : uint32_t;
+  (* not used at the moment *)
   compat_flags : uint32_t;
   (* refuse to mount if unknown incompat_flags are set *)
   incompat_flags : uint32_t;
@@ -491,9 +499,6 @@ type relax = {
 }
 
 type mount_options = {
-  (* Whether the empty value should be considered a tombstone,
-   * meaning that `mem` will return no value when finding it *)
-  has_tombstone : bool;
   (* If enabled, instead of checking the entire filesystem when opening,
    * leaf nodes won't be scanned.  They will be scanned on open instead. *)
   fast_scan : bool;
@@ -503,6 +508,16 @@ type mount_options = {
   relax : relax;
 }
 
+module OptionalSuperblockFlags = struct
+  type t = int32
+
+  let empty = 0l
+
+  let tombstones_enabled = 1l
+
+  let intersect = Int32.logand
+end
+
 (* All parameters that can be read from the superblock *)
 module type SUPERBLOCK_PARAMS = sig
   (* Size of blocks, in bytes *)
@@ -510,6 +525,9 @@ module type SUPERBLOCK_PARAMS = sig
 
   (* The exact size of all keys, in bytes *)
   val key_size : int
+
+  (* The set of optional superblock flags *)
+  val optional_flags : int32
 end
 
 module type PARAMS = sig
@@ -518,7 +536,6 @@ end
 
 let standard_mount_options =
   {
-    has_tombstone = false;
     fast_scan = true;
     cache_size = 1024;
     relax = {magic_crc = false; magic_crc_write = false};
@@ -528,6 +545,8 @@ module StandardSuperblockParams : SUPERBLOCK_PARAMS = struct
   let block_size = 256 * 1024
 
   let key_size = 20
+
+  let optional_flags = OptionalSuperblockFlags.empty
 end
 
 type deviceOpenMode =
@@ -573,7 +592,7 @@ module type S = sig
 
   val next_key : key -> key
 
-  val is_tombstone : root -> value -> bool
+  val is_tombstone : value -> bool
 
   val insert : root -> key -> value -> unit Lwt.t
 
@@ -631,6 +650,24 @@ module Testing = struct
     else false
 end
 
+(** Return optional flags, raising if any incompat flags can't be supported *)
+let validate_and_extract_superblock_flags sb =
+  (* NB: No compat flags are used at the moment *)
+  let flags = get_superblock_incompat_flags sb in
+  if Int32.logand flags sb_required_incompat <> sb_required_incompat then
+    (* Required flags don't match, some are missing *)
+    raise BadFlags;
+  let remflags = Int32.logand flags (Int32.lognot sb_required_incompat) in
+  if Int32.logor remflags sb_accepted_incompat <> sb_accepted_incompat then
+    (* There are some incompat flags we don't understand and can't support *)
+    raise BadFlags;
+  let optflags = Int32.logand remflags sb_optional_incompat in
+  if optflags = sb_incompat_tombstones then
+    OptionalSuperblockFlags.tombstones_enabled
+  else (
+    assert (optflags = 0l);
+    OptionalSuperblockFlags.empty )
+
 let read_superblock_params (type disk)
     (module B : Mirage_block.S with type t = disk) disk relax =
   let block_io = get_superblock_io () in
@@ -647,12 +684,15 @@ let read_superblock_params (type disk)
             then raise BadFlags
             else if not (cstruct_valid sb relax) then raise (BadCRC 0L)
             else
+              let optional_flags = validate_and_extract_superblock_flags sb in
               let block_size = Int32.to_int (get_superblock_block_size sb) in
               let key_size = get_superblock_key_size sb in
               ( module struct
                 let block_size = block_size
 
                 let key_size = key_size
+
+                let optional_flags = optional_flags
               end : SUPERBLOCK_PARAMS ))
 
 module Make (B : EXTBLOCK) (P : SUPERBLOCK_PARAMS) : S with type disk = B.t =
@@ -749,8 +789,10 @@ struct
     root_key : AllocId.t;
   }
 
-  let is_tombstone root value =
-    root.open_fs.filesystem.mount_options.has_tombstone
+  let is_tombstone value =
+    OptionalSuperblockFlags.intersect P.optional_flags
+      OptionalSuperblockFlags.tombstones_enabled
+    <> OptionalSuperblockFlags.empty
     && String.length value = 0
 
   let load_data_at filesystem logical =
@@ -1455,16 +1497,6 @@ struct
         | Some centry -> centry.meta <- Child alloc_id)
       entry.children_alloc_ids
 
-  let value_at fs va =
-    let len = String.length va in
-    if fs.mount_options.has_tombstone && len = 0 then None else Some va
-
-  let is_value fs va =
-    if not fs.mount_options.has_tombstone then true
-    else
-      let len = String.length va in
-      len <> 0
-
   (* lwt because it might load from disk *)
   let rec reserve_insert fs alloc_id space split_path depth =
     (*Logs.debug (fun m -> m "reserve_insert %Ld" depth);*)
@@ -1695,7 +1727,7 @@ struct
     | Some entry -> (
         match KeyedMap.find_opt entry.logdata.contents key with
         | Some va ->
-            if is_value open_fs.filesystem va then Lwt.return_some va
+            if not (is_tombstone va) then Lwt.return_some va
             else Lwt.return_none
         | None ->
             if not (has_children entry) then Lwt.return_none
@@ -1711,7 +1743,7 @@ struct
     | None -> raise (MissingLRUEntry alloc_id)
     | Some entry -> (
         match KeyedMap.find_opt entry.logdata.contents key with
-        | Some va -> Lwt.return (is_value open_fs.filesystem va)
+        | Some va -> Lwt.return (not (is_tombstone va))
         | None ->
             Logs.debug (fun m -> m "_mem");
             if not (has_children entry) then Lwt.return_false
@@ -1743,9 +1775,7 @@ struct
         (* The range from start inclusive to end_ exclusive *)
         KeyedMap.iter_range
           (fun k va ->
-            ( match value_at open_fs.filesystem va with
-            | Some v -> callback k v
-            | None -> () );
+            if not (is_tombstone va) then callback k va;
             seen1 := KeyedSet.add k !seen1)
           entry.logdata.contents start end_;
         (* As above, but end at end_ inclusive *)
@@ -1776,10 +1806,7 @@ struct
     | Some entry ->
         let lwt_queue = ref [] in
         KeyedMap.iter
-          (fun k va ->
-            match value_at open_fs.filesystem va with
-            | Some v -> callback k v
-            | None -> ())
+          (fun k va -> if not (is_tombstone va) then callback k va)
           entry.logdata.contents;
         KeyedMap.iter
           (fun key1 _logical -> lwt_queue := key1 :: !lwt_queue)

--- a/tests/wodan-irmin/test_wodan.ml
+++ b/tests/wodan-irmin/test_wodan.ml
@@ -25,7 +25,7 @@ module BlockCon = struct
 end
 
 module DB_ram =
-  Wodan_irmin.DB_BUILDER (BlockCon) (Wodan.StandardSuperblockParams)
+  Wodan_irmin.DB_BUILDER (BlockCon) (Wodan_irmin.StandardSuperblockParams)
 
 (* let store = Irmin_test.store (module Wodan_irmin.Make(DB_ram)) (module Irmin.Metadata.None) *)
 let store =


### PR DESCRIPTION
The first commit switches tombstones to a flag on the superblock, making it constant instead of per-mount.
This ensures empty values keep their semantics across mounts.

The second commit fixes a bug with the Irmin interfaces we provide.
We now prefix values at the wodan-irmin level so that we can both use tombstones (needed for some Irmin ATOMIC_WRITE_STORE operations) and allow Irmin serialisation to provide empty values without them being interpreted as tombstones.