### PR TITLE
Fully remove rresult

### DIFF
--- a/src/wodan-irmin/dune
+++ b/src/wodan-irmin/dune
@@ -5,5 +5,4 @@
  (ocamlopt_flags :standard -g -O3)
  (preprocess
   (pps lwt_ppx))
- (libraries wodan irmin irmin-chunk irmin-git logs mirage-block fmt rresult
-   result))
+ (libraries wodan irmin irmin-chunk irmin-git logs mirage-block fmt))

--- a/src/wodan-irmin/wodan_irmin.ml
+++ b/src/wodan-irmin/wodan_irmin.ml
@@ -282,7 +282,7 @@ functor
       | None -> Lwt.return_none
       | Some v ->
           Lwt.return_some
-            (Rresult.R.get_ok
+            (Result.get_ok
                (Irmin.Type.of_bin_string V.t (DB.Stor.string_of_value v)))
 
     let mem db k =
@@ -347,7 +347,7 @@ functor
       | None -> Lwt.return_none
       | Some v ->
           Lwt.return_some
-            (Rresult.R.get_ok
+            (Result.get_ok
                (Irmin.Type.of_bin_string V.t (DB.Stor.string_of_value v)))
 
     let mem db k =
@@ -418,10 +418,10 @@ functor
       Stor.value_of_string (Irmin.Type.to_bin_string K.t k)
 
     let key_of_inner_val va =
-      Rresult.R.get_ok (Irmin.Type.of_bin_string K.t (Stor.string_of_value va))
+      Result.get_ok (Irmin.Type.of_bin_string K.t (Stor.string_of_value va))
 
     let val_of_inner_val va =
-      Rresult.R.get_ok (Irmin.Type.of_bin_string V.t (Stor.string_of_value va))
+      Result.get_ok (Irmin.Type.of_bin_string V.t (Stor.string_of_value va))
 
     let inner_val_to_inner_key va =
       Stor.key_of_string

--- a/src/wodan-unix/dune
+++ b/src/wodan-unix/dune
@@ -4,8 +4,8 @@
  (flags :standard -g)
  (ocamlopt_flags :standard -g -O3)
  (package wodan-unix)
- (libraries base64 benchmark csv cmdliner wodan io-page-unix result rresult
-   logs cstruct mirage-block mirage-block-unix mirage-block-ramdisk
-   nocrypto.lwt afl-persistent lwt.unix)
+ (libraries base64 benchmark csv cmdliner wodan io-page-unix logs cstruct
+   mirage-block mirage-block-unix mirage-block-ramdisk nocrypto.lwt
+   afl-persistent lwt.unix)
  (preprocess
   (pps lwt_ppx)))

--- a/src/wodan-unix/unikernel.ml
+++ b/src/wodan-unix/unikernel.ml
@@ -226,7 +226,7 @@ module Client (B : Wodan.EXTBLOCK) = struct
           ~size_sectors:Int64.(div (of_int disk_size) 512L)
           ~sector_size:512
       in
-      let disk = Rresult.R.get_ok disk_res in
+      let disk = Result.get_ok disk_res in
       let%lwt info = Ramdisk.get_info disk in
       Lwt.return (disk, info)
     in


### PR DESCRIPTION
It was only useful for compatibility.
Follow-up to 5367855c40d3bc466e5a4e6eb70d20c4b406c076.