### PR TITLE
Ocaml 4.12

### DIFF
--- a/src/wodan-irmin/dune
+++ b/src/wodan-irmin/dune
@@ -5,4 +5,4 @@
  (ocamlopt_flags :standard -g -O3)
  (preprocess
   (pps lwt_ppx))
- (libraries wodan irmin irmin-chunk irmin-git logs mirage-block fmt))
+ (libraries wodan irmin irmin-chunk irmin-git logs mirage-block fmt repr))

--- a/src/wodan/crc32c.ml
+++ b/src/wodan/crc32c.ml
@@ -31,7 +31,7 @@ let optint_to_uint32 i = Optint.to_int32 i
 let cstruct ?(crc = 0l) cstr =
   optint_to_uint32
     (Checkseum.Crc32c.digest_bigstring (Cstruct.to_bigarray cstr) 0
-       (Cstruct.len cstr) (optint_of_uint32 crc))
+       (Cstruct.length cstr) (optint_of_uint32 crc))
 
 let cstruct_valid str = ~~~(cstruct str) = 0l
 
@@ -39,6 +39,6 @@ let cstruct_valid str = ~~~(cstruct str) = 0l
 let cstr = Cstruct.of_string "123456789...." in begin cstruct_reset cstr; cstruct_valid cstr end
 *)
 let cstruct_reset str =
-  let sublen = Cstruct.len str - 4 in
+  let sublen = Cstruct.length str - 4 in
   let crc = cstruct (Cstruct.sub str 0 sublen) in
   Cstruct.LE.set_uint32 str sublen ~~~crc

--- a/src/wodan/wodan.ml
+++ b/src/wodan/wodan.ml
@@ -228,7 +228,7 @@ let sizeof_logical = 8
 
 let make_fanned_io_list size cstr =
   let r = ref [] in
-  let l = Cstruct.len cstr in
+  let l = Cstruct.length cstr in
   let rec iter off =
     if off = 0 then ()
     else
@@ -683,7 +683,7 @@ end
 let magic_crc = Cstruct.of_string "\xff\xff\xff\xff"
 
 let has_magic_crc cstr =
-  let crcoffset = Cstruct.len cstr - 4 in
+  let crcoffset = Cstruct.length cstr - 4 in
   let crc = Cstruct.sub cstr crcoffset 4 in
   (* Don't use Cstruct.equal, it will use memcmp, be opaque to AFL *)
   (*Cstruct.equal crc magic_crc*)
@@ -697,7 +697,7 @@ let cstruct_valid cstr relax =
 
 let cstruct_reset cstr relax =
   if relax.magic_crc_write then
-    let crcoffset = Cstruct.len cstr - 4 in
+    let crcoffset = Cstruct.length cstr - 4 in
     Cstruct.blit magic_crc 0 cstr crcoffset 4
   else Crc32c.cstruct_reset cstr
 
@@ -771,7 +771,7 @@ struct
   end
 
   let key_of_cstruct key =
-    if Cstruct.len key <> P.key_size then
+    if Cstruct.length key <> P.key_size then
       raise (BadKey (Cstruct.to_string key))
     else Cstruct.to_string key
 
@@ -921,7 +921,7 @@ struct
     Logs.debug (fun m -> m "load_root_node_at");
     let%lwt cstr = load_data_at open_fs.filesystem logical in
     let cache = open_fs.node_cache in
-    assert (Cstruct.len cstr = P.block_size);
+    assert (Cstruct.length cstr = P.block_size);
     let meta, logdata =
       match get_anynode_hdr_nodetype cstr with
       | 1 -> (Root, index_logdata cstr sizeof_rootnode_hdr)
@@ -951,7 +951,7 @@ struct
     let cache = open_fs.node_cache in
     assert (Bitv64.get cache.space_map logical);
     let%lwt cstr = load_data_at open_fs.filesystem logical in
-    assert (Cstruct.len cstr = P.block_size);
+    assert (Cstruct.length cstr = P.block_size);
     let meta, logdata =
       match get_anynode_hdr_nodetype cstr with
       | 2 -> (Child parent_key, index_logdata cstr sizeof_childnode_hdr)
@@ -1222,7 +1222,7 @@ struct
     Logs.debug (fun m ->
         m "new_node type:%d alloc_id:%a" tycode AllocId.pp alloc_id);
     let cstr = get_block_io () in
-    assert (Cstruct.len cstr = P.block_size);
+    assert (Cstruct.length cstr = P.block_size);
     set_anynode_hdr_nodetype cstr tycode;
     set_anynode_hdr_fsid cache.fsid 0 cstr;
     let meta =

--- a/tests/wodan-irmin/test_wodan.ml
+++ b/tests/wodan-irmin/test_wodan.ml
@@ -43,4 +43,4 @@ let init () = Nocrypto_entropy_lwt.initialize ()
 
 let stats = None
 
-let suite = {Irmin_test.name = "WODAN"; init; clean; config; store; stats}
+let suite = {Irmin_test.name = "WODAN"; Irmin_test.layered_store=None; init; clean; config; store; stats; }

--- a/wodan-irmin.opam
+++ b/wodan-irmin.opam
@@ -31,7 +31,7 @@ depends: [
   "checkseum" {>= "0.0.2"}
   "digestif"
   "io-page-unix"
-  "irmin"
+  "irmin" {>= "2.7.2"}
   "irmin-chunk"
   "irmin-git"
   "irmin-unix"

--- a/wodan.opam
+++ b/wodan.opam
@@ -27,7 +27,7 @@ depends: [
   "dune"  {>= "1.7"}
   "bitv"
   "checkseum" {>= "0.0.2"}
-  "cstruct"
+  "cstruct" {>= "6.0.0"}
   "diet" {>= "0.4"}
   "fmt" {with-test}
   "io-page"


### PR DESCRIPTION
Here is an update that compiles with ocaml 4.12 and Irmin 2.7.2. The implementation of ```clear``` is still missing and therefore the corresponding test fails.